### PR TITLE
Chore/rename builder controller

### DIFF
--- a/app/assets/javascripts/slotcars/build/build_screen.js.coffee
+++ b/app/assets/javascripts/slotcars/build/build_screen.js.coffee
@@ -1,9 +1,11 @@
 
 #= require helpers/namespace
 #= require slotcars/build/views/build_screen_view
-#= require slotcars/build/controllers/builder_controller
+#= require slotcars/build/builder
 
 namespace 'slotcars.build'
+
+BuilderController = slotcars.build.Builder
 
 slotcars.build.BuildScreen = Ember.Object.extend
 
@@ -19,7 +21,7 @@ slotcars.build.BuildScreen = Ember.Object.extend
     @_buildScreenView.append()
 
   setupBuilder: ->
-    @_builderController = slotcars.build.controllers.BuilderController.create
+    @_builderController = BuilderController.create
       buildScreenView: @_buildScreenView
 
   destroy: ->

--- a/app/assets/javascripts/slotcars/build/builder.js.coffee
+++ b/app/assets/javascripts/slotcars/build/builder.js.coffee
@@ -4,9 +4,9 @@
 #= require slotcars/build/controllers/draw_controller
 #= require slotcars/build/views/draw_view
 
-namespace 'slotcars.build.controllers'
+namespace 'slotcars.build'
 
-slotcars.build.controllers.BuilderController = Ember.Object.extend
+slotcars.build.Builder = Ember.Object.extend
 
   track: null
   drawController: null

--- a/spec/javascripts/unit/slotcars/build/build_screen_spec.js.coffee
+++ b/spec/javascripts/unit/slotcars/build/build_screen_spec.js.coffee
@@ -1,12 +1,12 @@
 
 #= require slotcars/build/build_screen
 #= require slotcars/build/views/build_screen_view
-#= require slotcars/build/controllers/builder_controller
+#= require slotcars/build/builder
 
 describe 'slotcars.build.BuildScreen', ->
 
   BuildScreen = slotcars.build.BuildScreen
-  BuilderController = slotcars.build.controllers.BuilderController
+  BuilderController = slotcars.build.Builder
   BuilderScreenView = slotcars.build.views.BuildScreenView
 
   beforeEach ->

--- a/spec/javascripts/unit/slotcars/build/builder_spec.js.coffee
+++ b/spec/javascripts/unit/slotcars/build/builder_spec.js.coffee
@@ -1,12 +1,12 @@
 
-#= require slotcars/build/controllers/builder_controller
+#= require slotcars/build/builder
 #= require slotcars/shared/models/track_model
 #= require slotcars/build/controllers/draw_controller
 #= require slotcars/build/views/draw_view
 
 describe 'builder controller', ->
 
-  BuilderController = slotcars.build.controllers.BuilderController
+  BuilderController = slotcars.build.Builder
   DrawController = slotcars.build.controllers.DrawController
   DrawView = slotcars.build.views.DrawView
 


### PR DESCRIPTION
Moves and renames slotcars.build.controllers.BuilderController to slotcars.build.Builder since it is not a controller but the initializer for the builder application

closes #62
