### PR TITLE
Feature/multiple laps

### DIFF
--- a/app/assets/javascripts/slotcars/play/controllers/game_controller.js.coffee
+++ b/app/assets/javascripts/slotcars/play/controllers/game_controller.js.coffee
@@ -23,6 +23,7 @@ slotcars.play.controllers.GameController = Ember.Object.extend
   raceTime: null
 
   init: ->
+    (@get 'car').set 'track', (@get 'track')
     @gameLoopController = GameLoopController.create()
 
     (jQuery document).on 'touchMouseDown', (event) => @onTouchMouseDown event
@@ -41,14 +42,17 @@ slotcars.play.controllers.GameController = Ember.Object.extend
     @car.jumpstart()
     @car.reset()
 
-    (jQuery @car).on 'crossFinishLine', => @finish()
     @gameLoopController.start => @update()
 
   finish: ->
-    (jQuery @car).off 'crossFinishLine'
     @endTime = new Date().getTime()
     @set 'raceTime', @endTime - @startTime
     @car.reset()
+
+  onCarCrossedFinishLine: (->
+    car = @get 'car'
+    if car.get 'crossedFinishLine' then @finish()
+  ).observes 'car.crossedFinishLine'
 
   update: ->
     unless @car.isCrashing
@@ -72,9 +76,6 @@ slotcars.play.controllers.GameController = Ember.Object.extend
       @car.jumpstart()
       @car.moveTo { x: nextPosition.x, y: nextPosition.y }
 
-      if (@car.get 'lengthAtTrack') >= @track.getTotalLength()
-        (jQuery @car).trigger 'crossFinishLine'
-
 
   onTouchMouseDown: (event) ->
     event.originalEvent.preventDefault()
@@ -90,8 +91,6 @@ slotcars.play.controllers.GameController = Ember.Object.extend
 
     position = @track.getPointAtLength 0
     @car.moveTo { x: position.x, y: position.y }
-
-    (jQuery @car).on 'crossFinishLine', => @finish()
 
   _resetTime: ->
     @set 'raceTime', 0

--- a/app/assets/javascripts/slotcars/shared/models/car.js.coffee
+++ b/app/assets/javascripts/slotcars/shared/models/car.js.coffee
@@ -23,7 +23,7 @@ slotcars.shared.models.Car = Ember.Object.extend Movable, Crashable,
   track: null
   lengthAtTrack: 0
 
-  currentLap: 1
+  currentLap: 0
   crossedFinishLine: false
 
   _onLengthAtTrackChanged: (->

--- a/app/assets/javascripts/slotcars/shared/models/car.js.coffee
+++ b/app/assets/javascripts/slotcars/shared/models/car.js.coffee
@@ -20,7 +20,21 @@ slotcars.shared.models.Car = Ember.Object.extend Movable, Crashable,
   deceleration: 0
   crashDeceleration: 0
 
+  track: null
   lengthAtTrack: 0
+
+  currentLap: 1
+  crossedFinishLine: false
+
+  _onLengthAtTrackChanged: (->
+    track = @get 'track'
+    if track?
+      lapForLengthAtTrack = (track.lapForLength @get 'lengthAtTrack')
+      if lapForLengthAtTrack isnt @get 'currentLap' then @set 'currentLap', lapForLengthAtTrack
+
+      isLengthAfterFinishLine = (track.isLengthAfterFinishLine @get 'lengthAtTrack')
+      if isLengthAfterFinishLine isnt @get 'crossedFinishLine' then @set 'crossedFinishLine', isLengthAfterFinishLine
+  ).observes 'lengthAtTrack'
 
   drive: ->
     newLength = (@get 'lengthAtTrack') + (@get 'speed')
@@ -43,4 +57,4 @@ slotcars.shared.models.Car = Ember.Object.extend Movable, Crashable,
 
   reset: ->
     @speed = 0
-    @lengthAtTrack = 0
+    @set 'lengthAtTrack', 0

--- a/app/assets/javascripts/slotcars/shared/models/track.js.coffee
+++ b/app/assets/javascripts/slotcars/shared/models/track.js.coffee
@@ -18,7 +18,7 @@ slotcars.shared.models.Track = DS.Model.extend
   _shouldUpdateRasterizedPath: false
   raphaelPath: EMPTY_RAPHAEL_PATH
 
-  numberOfLaps: 1
+  numberOfLaps: 3
 
   init: ->
     @_super()
@@ -58,7 +58,11 @@ slotcars.shared.models.Track = DS.Model.extend
     @getTotalLength() * (@get 'numberOfLaps') < length
 
   lapForLength: (length) ->
-    lap = Math.floor length / @getTotalLength()
+    lap = Math.ceil length / @getTotalLength()
+    numberOfLaps = @get 'numberOfLaps'
+    
+    # clamp return value to maximum number of laps
+    if lap > numberOfLaps then lap = numberOfLaps
     if lap is 0 then return 1 else return lap
 
   # Generates catmull-rom paths for raphel with format: x1 y1 (x y)+

--- a/app/assets/javascripts/slotcars/shared/models/track.js.coffee
+++ b/app/assets/javascripts/slotcars/shared/models/track.js.coffee
@@ -18,6 +18,8 @@ slotcars.shared.models.Track = DS.Model.extend
   _shouldUpdateRasterizedPath: false
   raphaelPath: EMPTY_RAPHAEL_PATH
 
+  numberOfLaps: 1
+
   init: ->
     @_super()
     @_path = Path.create()
@@ -51,6 +53,13 @@ slotcars.shared.models.Track = DS.Model.extend
     clientId = @get('clientId')
     "play/#{clientId}"
   ).property 'clientId'
+
+  isLengthAfterFinishLine: (length) ->
+    @getTotalLength() * (@get 'numberOfLaps') < length
+
+  lapForLength: (length) ->
+    lap = Math.floor length / @getTotalLength()
+    if lap is 0 then return 1 else return lap
 
   # Generates catmull-rom paths for raphel with format: x1 y1 (x y)+
   # which results in pathes like: M0,0R,1,0,3,2,4,5z

--- a/spec/javascripts/helpers/jasmine/custom_matchers.js.coffee
+++ b/spec/javascripts/helpers/jasmine/custom_matchers.js.coffee
@@ -15,3 +15,6 @@ beforeEach ->
 
     toExtend: (expectedClass) ->
       expectedClass.detect @actual
+
+    toObserve: (expectedBindingPath) ->
+      @env.equals_ @actual.__ember_observes__[0], expectedBindingPath

--- a/spec/javascripts/unit/slotcars/shared/models/car_spec.js.coffee
+++ b/spec/javascripts/unit/slotcars/shared/models/car_spec.js.coffee
@@ -4,6 +4,7 @@
 #= require slotcars/shared/lib/crashable
 
 #= require helpers/math/vector
+#= require slotcars/shared/models/track
 
 describe 'slotcars.shared.models.Car', ->
 
@@ -11,6 +12,7 @@ describe 'slotcars.shared.models.Car', ->
   Vector = helpers.math.Vector
   Movable = slotcars.shared.lib.Movable
   Crashable = slotcars.shared.lib.Crashable
+  Track = slotcars.shared.models.Track
 
   describe 'usage of mixins', ->
 
@@ -118,11 +120,51 @@ describe 'slotcars.shared.models.Car', ->
   describe '#drive', ->
 
     beforeEach ->
-      @car = Car.create
-        speed: 1
+      @car = Car.create speed: 1
 
     it 'should update lengthAtTrack', ->
       @car.drive()
 
       (expect @car.lengthAtTrack).toBe 1
 
+
+  describe 'reactions to changes of length at track', ->
+
+    beforeEach ->
+      @trackMock = mockEmberClass Track
+      @trackMock.lapForLength = sinon.stub().returns 1
+      @trackMock.isLengthAfterFinishLine = sinon.stub().returns false
+
+      @car = Car.create track: @trackMock
+
+    afterEach ->
+      @trackMock.restore()
+
+
+    describe 'current lap of car', ->
+
+      it 'should provide bindable property for the current lap the car is in', ->
+        @trackMock.lapForLength = sinon.stub().withArgs(0).returns 1
+
+        (expect @car.get 'currentLap').toBe 1
+
+      it 'should update currentLap when lengthAtTrack changes', ->
+        @trackMock.lapForLength = sinon.stub().withArgs(1).returns 2
+
+        @car.set 'lengthAtTrack', 2
+
+        (expect @car.get 'currentLap').toBe 2
+
+
+    describe 'crossing finish line', ->
+
+      it 'should provide property that is false by default', ->
+        (expect @car.get 'crossedFinishLine').toBe false
+
+      it 'should be set to true if lengthAtTrack gets bigger than length of finish line', ->
+        testLength = 3
+        @trackMock.isLengthAfterFinishLine.withArgs(testLength).returns true
+
+        @car.set 'lengthAtTrack', testLength
+
+        (expect @car.get 'crossedFinishLine').toBe true

--- a/spec/javascripts/unit/slotcars/shared/models/car_spec.js.coffee
+++ b/spec/javascripts/unit/slotcars/shared/models/car_spec.js.coffee
@@ -40,6 +40,9 @@ describe 'slotcars.shared.models.Car', ->
     it 'should set crashing to false', ->
       (expect @car.isCrashing).toBe false
 
+    it 'should set currentLap to zero', ->
+      (expect @car.get 'currentLap').toBe 0
+
 
   describe '#accelerate', ->
 
@@ -142,11 +145,6 @@ describe 'slotcars.shared.models.Car', ->
 
 
     describe 'current lap of car', ->
-
-      it 'should provide bindable property for the current lap the car is in', ->
-        @trackMock.lapForLength = sinon.stub().withArgs(0).returns 1
-
-        (expect @car.get 'currentLap').toBe 1
 
       it 'should update currentLap when lengthAtTrack changes', ->
         @trackMock.lapForLength = sinon.stub().withArgs(1).returns 2

--- a/spec/javascripts/unit/slotcars/shared/models/track_spec.js.coffee
+++ b/spec/javascripts/unit/slotcars/shared/models/track_spec.js.coffee
@@ -134,6 +134,7 @@ describe 'slotcars.shared.models.Track', ->
       (expect raphaelPathObserver).toHaveBeenCalled()
 
 
+
   describe 'route to the track resource', ->
 
     it 'should return the correct route with client id', ->
@@ -141,3 +142,51 @@ describe 'slotcars.shared.models.Track', ->
       id = track.get 'clientId'
 
       (expect track.get 'playRoute').toEqual "play/#{id}"
+
+
+  describe 'lap count for tracks', ->
+
+    it 'should return the same static number of laps for all tracks', ->
+      @track = Track.createRecord()
+
+      (expect @track.get 'numberOfLaps').toBe 3
+
+
+  describe 'asking if specific length on track is after finish line', ->
+
+    beforeEach ->
+      @fakePathLength = 1
+      @pathMock.getTotalLength = sinon.stub().returns @fakePathLength
+      @track = Track.createRecord()
+
+    it 'should return true when asked for length after finish line', ->
+      lengthThatShouldBeAfter = (@track.get 'numberOfLaps') * @fakePathLength + 0.00001
+      (expect @track.isLengthAfterFinishLine lengthThatShouldBeAfter).toBe true
+
+    it 'should return false when asked length is before finish line', ->
+      lengthThatShouldNotBeAfter = (@track.get 'numberOfLaps') * @fakePathLength - 0.00001
+      (expect @track.isLengthAfterFinishLine lengthThatShouldNotBeAfter).toBe false
+
+
+  describe 'asking for lap at length', ->
+
+    beforeEach ->
+      @fakePathLength = 1
+      @pathMock.getTotalLength = sinon.stub().returns @fakePathLength
+      @track = Track.createRecord()
+
+    it 'should return first lap for lengths smaller than the path length', ->
+      lengthLessThanFirstLap = @fakePathLength - 0.0001
+
+      (expect @track.lapForLength lengthLessThanFirstLap).toBe 1
+
+    it 'should return first lap for length equal to the path length', ->
+      lengthEqualFirstLap = @fakePathLength
+
+      (expect @track.lapForLength lengthEqualFirstLap).toBe 1
+
+    it 'should return lap X for total path length multiplied by X', ->
+      X = Math.round(Math.random() * 10) + 1
+      lengthX = @fakePathLength * X
+
+      (expect @track.lapForLength lengthX).toBe X

--- a/spec/javascripts/unit/slotcars/shared/models/track_spec.js.coffee
+++ b/spec/javascripts/unit/slotcars/shared/models/track_spec.js.coffee
@@ -180,13 +180,12 @@ describe 'slotcars.shared.models.Track', ->
 
       (expect @track.lapForLength lengthLessThanFirstLap).toBe 1
 
-    it 'should return first lap for length equal to the path length', ->
-      lengthEqualFirstLap = @fakePathLength
+    it 'should return second lap for length between first and second lap', ->
+      lengthBetweenFirstAndSecondLap = @fakePathLength + 0.0001
 
-      (expect @track.lapForLength lengthEqualFirstLap).toBe 1
+      (expect @track.lapForLength lengthBetweenFirstAndSecondLap).toBe 2
 
-    it 'should return lap X for total path length multiplied by X', ->
-      X = Math.round(Math.random() * 10) + 1
-      lengthX = @fakePathLength * X
+    it 'should clamp the return value to maximum number of laps', ->
+      lengthBiggerThanTotalLaps = @fakePathLength * (@track.get 'numberOfLaps') + 1
 
-      (expect @track.lapForLength lengthX).toBe X
+      (expect @track.lapForLength lengthBiggerThanTotalLaps).toBe @track.get 'numberOfLaps'


### PR DESCRIPTION
Implements the multiple laps feature by moving the "crossed finish line" logic into the car / track model. Track got two simple methods to look up if a certain length is behind the finish line and which lap it represents. The Car model now has a track and works with it to decide in which lap it is in and if it has finished the race.

The game controller only observes the 'crossedFinishLine' property on the car which is boolean and simply changes to `true` when the race is over.
