### PR TITLE
Feature/starting lights

### DIFF
--- a/app/assets/javascripts/slotcars/play/controllers/game_controller.js.coffee
+++ b/app/assets/javascripts/slotcars/play/controllers/game_controller.js.coffee
@@ -19,8 +19,9 @@ slotcars.play.controllers.GameController = Ember.Object.extend
   gameLoopController: null
   isTouchMouseDown: false
   carControlsEnabled: false
-
-  countdownInSeconds: 3
+  
+  showCountdown: false
+  currentCountdownValue: null
 
   startTime: null
   endTime: null
@@ -81,6 +82,8 @@ slotcars.play.controllers.GameController = Ember.Object.extend
     @isTouchMouseDown = false
 
   restartGame: ->
+    @set 'carControlsEnabled', false
+
     position = @track.getPointAtLength 0
     @car.moveTo { x: position.x, y: position.y }
 
@@ -91,7 +94,16 @@ slotcars.play.controllers.GameController = Ember.Object.extend
 
     @set 'raceTime', 0
 
+    @set 'currentCountdownValue', 3
+    @set 'showCountdown', true
+
+    setTimeout (=> @set 'currentCountdownValue', 2 ), 1000
+    setTimeout (=> @set 'currentCountdownValue', 1 ), 2000
+
     setTimeout (=>
       @set 'carControlsEnabled', true
       @startTime = new Date().getTime()
-    ), @countdownInSeconds * 1000
+      @set 'currentCountdownValue', 'Go!'
+    ), 3000
+
+    setTimeout (=> @set 'showCountdown', false ), 4000

--- a/app/assets/javascripts/slotcars/play/controllers/game_controller.js.coffee
+++ b/app/assets/javascripts/slotcars/play/controllers/game_controller.js.coffee
@@ -20,7 +20,7 @@ slotcars.play.controllers.GameController = Ember.Object.extend
   isTouchMouseDown: false
   carControlsEnabled: false
   
-  showCountdown: false
+  isCountdownVisible: false
   currentCountdownValue: null
 
   startTime: null
@@ -83,6 +83,7 @@ slotcars.play.controllers.GameController = Ember.Object.extend
 
   restartGame: ->
     @set 'carControlsEnabled', false
+    @set 'raceTime', 0
 
     position = @track.getPointAtLength 0
     @car.moveTo { x: position.x, y: position.y }
@@ -92,10 +93,8 @@ slotcars.play.controllers.GameController = Ember.Object.extend
 
     (jQuery @car).on 'crossFinishLine', => @finish()
 
-    @set 'raceTime', 0
-
     @set 'currentCountdownValue', 3
-    @set 'showCountdown', true
+    @set 'isCountdownVisible', true
 
     setTimeout (=> @set 'currentCountdownValue', 2 ), 1000
     setTimeout (=> @set 'currentCountdownValue', 1 ), 2000
@@ -106,4 +105,4 @@ slotcars.play.controllers.GameController = Ember.Object.extend
       @set 'currentCountdownValue', 'Go!'
     ), 3000
 
-    setTimeout (=> @set 'showCountdown', false ), 4000
+    setTimeout (=> @set 'isCountdownVisible', false ), 3500

--- a/app/assets/javascripts/slotcars/play/game.js.coffee
+++ b/app/assets/javascripts/slotcars/play/game.js.coffee
@@ -24,7 +24,8 @@ slotcars.play.Game = Ember.Object.extend
     @_gameController = GameController.create track: @track, car: @car
 
     @_carView = CarView.create car: @car
-    @_trackView = TrackView.create()
+    @_trackView = TrackView.create gameController: @_gameController
+
     @_gameView = GameView.create gameController: @_gameController
 
     @_appendViews()

--- a/app/assets/javascripts/slotcars/play/play_screen_state_manager.js.coffee
+++ b/app/assets/javascripts/slotcars/play/play_screen_state_manager.js.coffee
@@ -6,7 +6,6 @@ namespace 'slotcars.play'
 slotcars.play.PlayScreenStateManager = Ember.StateManager.extend
 
   initialState: 'Loading'
-  enableLogging: true
   delegate: null
 
   Loading: Ember.State.create

--- a/app/assets/javascripts/slotcars/play/templates/game_template.js.hjs
+++ b/app/assets/javascripts/slotcars/play/templates/game_template.js.hjs
@@ -1,3 +1,3 @@
 <div id="race-time">{{raceTimeInSeconds}} seconds</div>
 <button id="restart-button" type="button" {{action "onRestartClick"}}>restart game</button>
-<div id="countdown">{{countdown}}</div>
+<div id="countdown" style="color: white; font-size: 270px; position: absolute; top: 210px; left: 300px; font-weight: bold; font-family: sans-serif; width: 400px; text-align: center; text-shadow: 0 0 15px #eee;">{{gameController.currentCountdownValue}}</div>

--- a/app/assets/javascripts/slotcars/play/templates/game_template.js.hjs
+++ b/app/assets/javascripts/slotcars/play/templates/game_template.js.hjs
@@ -1,2 +1,3 @@
 <div id="race-time">{{raceTimeInSeconds}} seconds</div>
 <button id="restart-button" type="button" {{action "onRestartClick"}}>restart game</button>
+<div id="countdown">{{countdown}}</div>

--- a/app/assets/javascripts/slotcars/play/views/game_view.js.coffee
+++ b/app/assets/javascripts/slotcars/play/views/game_view.js.coffee
@@ -17,17 +17,12 @@ slotcars.play.views.GameView = Ember.View.extend
     @convertMillisecondsToSeconds (@gameController.get 'raceTime')
   ).property 'gameController.raceTime'
 
-  countdown: (Ember.computed ->
-    # currentCountdown = @gameController.get 'countdownInSeconds'
-    # interval = setInterval (=>
-    #   unless currentCountdown == 0
-    #     currentCountdown = currentCountdown - 1
-    #   else
-    #     currentCountdown = 'GO'
-    # ), 1000
-    # console.log currentCountdown
-    # currentCountdown
-  ).property 'currentCountdown'
+  onShowCountdownChange: ( ->
+    if @gameController.get 'showCountdown'
+      (@$ '#countdown').show() 
+    else 
+      (@$ '#countdown').hide()
+  ).observes 'gameController.showCountdown'
 
   convertMillisecondsToSeconds: (value) ->
     value / 1000

--- a/app/assets/javascripts/slotcars/play/views/game_view.js.coffee
+++ b/app/assets/javascripts/slotcars/play/views/game_view.js.coffee
@@ -17,12 +17,12 @@ slotcars.play.views.GameView = Ember.View.extend
     @convertMillisecondsToSeconds (@gameController.get 'raceTime')
   ).property 'gameController.raceTime'
 
-  onShowCountdownChange: ( ->
-    if @gameController.get 'showCountdown'
+  onCountdownVisibleChange: ( ->
+    if @gameController.get 'isCountdownVisible'
       (@$ '#countdown').show() 
     else 
       (@$ '#countdown').hide()
-  ).observes 'gameController.showCountdown'
+  ).observes 'gameController.isCountdownVisible'
 
   convertMillisecondsToSeconds: (value) ->
     value / 1000

--- a/app/assets/javascripts/slotcars/play/views/game_view.js.coffee
+++ b/app/assets/javascripts/slotcars/play/views/game_view.js.coffee
@@ -17,5 +17,17 @@ slotcars.play.views.GameView = Ember.View.extend
     @convertMillisecondsToSeconds (@gameController.get 'raceTime')
   ).property 'gameController.raceTime'
 
+  countdown: (Ember.computed ->
+    # currentCountdown = @gameController.get 'countdownInSeconds'
+    # interval = setInterval (=>
+    #   unless currentCountdown == 0
+    #     currentCountdown = currentCountdown - 1
+    #   else
+    #     currentCountdown = 'GO'
+    # ), 1000
+    # console.log currentCountdown
+    # currentCountdown
+  ).property 'currentCountdown'
+
   convertMillisecondsToSeconds: (value) ->
     value / 1000

--- a/app/assets/javascripts/slotcars/shared/views/track_view.js.coffee
+++ b/app/assets/javascripts/slotcars/shared/views/track_view.js.coffee
@@ -7,6 +7,7 @@ namespace 'slotcars.shared.views'
 slotcars.shared.views.TrackView = Ember.View.extend
 
   elementId: 'track-view'
+  gameController: null
   _paper: null
   _path: null
 
@@ -38,6 +39,16 @@ slotcars.shared.views.TrackView = Ember.View.extend
     @_drawPath path, @ASPHALT_WIDTH, @ASPHALT_COLOR
     @_drawDashedLine path
   
+  onCarControlsChange: (->
+    (jQuery @$()).off 'touchMouseDown'
+    (jQuery @$()).off 'touchMouseUp'
+
+    if @gameController.get 'carControlsEnabled'
+      (jQuery @$()).on 'touchMouseDown', (event) => @gameController.onTouchMouseDown event
+      (jQuery @$()).on 'touchMouseUp', (event) => @gameController.onTouchMouseUp event
+
+  ).observes 'gameController.carControlsEnabled'
+
   _drawPath: (path, width, color) ->
     path = @_paper.path path;
     path.attr 'stroke', color

--- a/app/assets/javascripts/slotcars/shared/views/track_view.js.coffee
+++ b/app/assets/javascripts/slotcars/shared/views/track_view.js.coffee
@@ -40,12 +40,12 @@ slotcars.shared.views.TrackView = Ember.View.extend
     @_drawDashedLine path
   
   onCarControlsChange: (->
-    (jQuery @$()).off 'touchMouseDown'
-    (jQuery @$()).off 'touchMouseUp'
+    (jQuery document).off 'touchMouseDown'
+    (jQuery document).off 'touchMouseUp'
 
     if @gameController.get 'carControlsEnabled'
-      (jQuery @$()).on 'touchMouseDown', (event) => @gameController.onTouchMouseDown event
-      (jQuery @$()).on 'touchMouseUp', (event) => @gameController.onTouchMouseUp event
+      (jQuery document).on 'touchMouseDown', (event) => @gameController.onTouchMouseDown event
+      (jQuery document).on 'touchMouseUp', (event) => @gameController.onTouchMouseUp event
 
   ).observes 'gameController.carControlsEnabled'
 

--- a/app/assets/javascripts/slotcars/shared/views/track_view.js.coffee
+++ b/app/assets/javascripts/slotcars/shared/views/track_view.js.coffee
@@ -40,12 +40,12 @@ slotcars.shared.views.TrackView = Ember.View.extend
     @_drawDashedLine path
   
   onCarControlsChange: (->
-    (jQuery document).off 'touchMouseDown'
-    (jQuery document).off 'touchMouseUp'
+    (jQuery @$()).off 'touchMouseDown'
+    (jQuery @$()).off 'touchMouseUp'
 
     if @gameController.get 'carControlsEnabled'
-      (jQuery document).on 'touchMouseDown', (event) => @gameController.onTouchMouseDown event
-      (jQuery document).on 'touchMouseUp', (event) => @gameController.onTouchMouseUp event
+      (jQuery @$()).on 'touchMouseDown', (event) => @gameController.onTouchMouseDown event
+      (jQuery @$()).on 'touchMouseUp', (event) => @gameController.onTouchMouseUp event
 
   ).observes 'gameController.carControlsEnabled'
 

--- a/spec/javascripts/unit/slotcars/play/controllers/game_controller_spec.js.coffee
+++ b/spec/javascripts/unit/slotcars/play/controllers/game_controller_spec.js.coffee
@@ -213,17 +213,14 @@ describe 'slotcars.play.controllers.GameController (unit)', ->
         moveTo: sinon.spy()
         jumpstart: sinon.spy()
 
-      @fakeTimer = sinon.useFakeTimers()
-
     afterEach ->
-      @fakeTimer.restore()
       @carMock.restore()
 
     it 'should reset raceTime', ->
       @gameController.raceTime = 18
       @gameController.restartGame()
 
-      (expect @gameController.raceTime).toBe 0
+      (expect @gameController.get 'raceTime').toBe 0
 
     it 'should reset car', ->
       @gameController.car = @carMock
@@ -231,19 +228,39 @@ describe 'slotcars.play.controllers.GameController (unit)', ->
 
       (expect @carMock.reset).toHaveBeenCalled()
 
-    it 'should enable controls after countdown', ->
-      @gameController.onTouchMouseDown = sinon.spy()
+    it 'should disable car controls', ->
       @gameController.restartGame()
 
-      (expect @gameController.carControlsEnabled).toBe false
-      @fakeTimer.tick 3010
-      (expect @gameController.carControlsEnabled).toBe true
+      (expect @gameController.get 'carControlsEnabled').toBe false
 
-    it 'should save timestamp after countdown', ->
+    it 'should set flag to show countdown', ->
       @gameController.restartGame()
+      
+      (expect @gameController.get 'isCountdownVisible').toBe true
 
-      @fakeTimer.tick 3010
+    describe 'after countdown', ->
 
-      (expect @gameController.get 'startTime').toNotBe null
+      beforeEach ->
+        @fakeTimer = sinon.useFakeTimers()
 
+      afterEach ->
+        @fakeTimer.restore()
 
+      it 'should enable controls after countdown', ->
+        @gameController.restartGame()
+
+        @fakeTimer.tick 3000
+        (expect @gameController.get 'carControlsEnabled').toBe true
+
+      it 'should save timestamp after countdown', ->
+        @gameController.restartGame()
+
+        @fakeTimer.tick 3000
+
+        (expect @gameController.get 'startTime').toNotBe null
+
+      it 'should set flag to hide countdown', ->
+        @gameController.restartGame()
+        @fakeTimer.tick 3500
+
+        (expect @gameController.get 'isCountdownVisible').toBe false

--- a/spec/javascripts/unit/slotcars/play/game_spec.js.coffee
+++ b/spec/javascripts/unit/slotcars/play/game_spec.js.coffee
@@ -61,7 +61,7 @@ describe 'game', ->
       (expect @GameViewMock.create).toHaveBeenCalledWithAnObjectLike gameController: @GameControllerMock
 
     it 'should create a track view', ->
-      (expect @TrackViewMock.create).toHaveBeenCalledWithAnObjectLike
+      (expect @TrackViewMock.create).toHaveBeenCalledWithAnObjectLike gameController: @GameControllerMock
 
     it 'should append car view to play screen view', ->
       (expect @playScreenViewMock.set).toHaveBeenCalledWith 'carView', @CarViewMock

--- a/spec/javascripts/unit/slotcars/play/views/game_view_spec.js.coffee
+++ b/spec/javascripts/unit/slotcars/play/views/game_view_spec.js.coffee
@@ -29,13 +29,3 @@ describe 'slotcars.play.views.GameView (unit)', ->
     @gameController.set 'raceTime', timeValue
 
     (expect @gameView.get 'raceTimeInSeconds').toBe @gameView.convertMillisecondsToSeconds timeValue
-
-  it 'should start countdown', ->
-    @gameController.set 'countdownInSeconds', 6
-    fakeTimer = sinon.useFakeTimers()
-
-    # (expect @gameView.get 'countdown').toBe 6
-
-    fakeTimer.tick 1010
-    # (expect @gameView.get 'countdown').toBe @gameController.countdownInSeconds - 1
-    fakeTimer.restore()

--- a/spec/javascripts/unit/slotcars/play/views/game_view_spec.js.coffee
+++ b/spec/javascripts/unit/slotcars/play/views/game_view_spec.js.coffee
@@ -18,7 +18,7 @@ describe 'slotcars.play.views.GameView (unit)', ->
   it 'should extend Ember.View', ->
     (expect GameView).toExtend Ember.View
 
-  it 'should restart game when restartGame event was triggered', ->
+  it 'should restart game when button was clicked', ->
     @gameController.restartGame = sinon.spy()
     @gameView.onRestartClick()
     
@@ -29,3 +29,13 @@ describe 'slotcars.play.views.GameView (unit)', ->
     @gameController.set 'raceTime', timeValue
 
     (expect @gameView.get 'raceTimeInSeconds').toBe @gameView.convertMillisecondsToSeconds timeValue
+
+  it 'should start countdown', ->
+    @gameController.set 'countdownInSeconds', 6
+    fakeTimer = sinon.useFakeTimers()
+
+    # (expect @gameView.get 'countdown').toBe 6
+
+    fakeTimer.tick 1010
+    # (expect @gameView.get 'countdown').toBe @gameController.countdownInSeconds - 1
+    fakeTimer.restore()

--- a/spec/javascripts/unit/slotcars/shared/views/track_view_spec.js.coffee
+++ b/spec/javascripts/unit/slotcars/shared/views/track_view_spec.js.coffee
@@ -65,7 +65,7 @@ describe 'track view', ->
 
       (expect @paperClearSpy).toHaveBeenCalled()
 
-  describe 'enable/disable car controls', ->
+  describe 'bind/unbind car controls', ->
 
     beforeEach ->
       @gameControllerMock.onTouchMouseDown = sinon.spy()
@@ -82,3 +82,11 @@ describe 'track view', ->
         (expect @gameControllerMock.onTouchMouseDown).toHaveBeenCalled()
 
     describe 'when controls are disabled', ->
+
+      it 'should call onTouchMouseDown on game controller when controls are enabled', ->
+        @gameControllerMock.get = sinon.stub().withArgs('carControlsEnabled').returns false
+        @trackView.onCarControlsChange()
+
+        (jQuery @trackView.$()).trigger 'touchMouseDown'
+
+        (expect @gameControllerMock.onTouchMouseDown).not.toHaveBeenCalled()

--- a/spec/javascripts/unit/slotcars/shared/views/track_view_spec.js.coffee
+++ b/spec/javascripts/unit/slotcars/shared/views/track_view_spec.js.coffee
@@ -1,27 +1,34 @@
 
 #= require slotcars/shared/views/track_view
+#= require slotcars/play/controllers/game_controller
 
 describe 'track view', ->
 
   TrackView = slotcars.shared.views.TrackView
+  GameController = slotcars.play.controllers.GameController
 
   beforeEach ->
-      @raphaelBackup = window.Raphael
-      @raphaelElementStub = sinon.stub().returns attr: ->
-      @paperClearSpy = sinon.spy()
+    @raphaelBackup = window.Raphael
+    @raphaelElementStub = sinon.stub().returns attr: ->
+    @paperClearSpy = sinon.spy()
 
-      @raphaelStub = window.Raphael = sinon.stub().returns
-        path: @raphaelElementStub
-        rect: @raphaelElementStub
-        clear: @paperClearSpy
+    @raphaelStub = window.Raphael = sinon.stub().returns
+      path: @raphaelElementStub
+      rect: @raphaelElementStub
+      clear: @paperClearSpy
 
-      @trackView = TrackView.create()
-      @trackView.appendTo '<div>'
+    @gameControllerMock = mockEmberClass GameController
 
-      Ember.run.end()
+    @trackView = TrackView.create
+      gameController: @gameControllerMock
+
+    @trackView.appendTo '<div>'
+
+    Ember.run.end()
 
   afterEach ->
     window.Raphael = @raphaelBackup
+    @gameControllerMock.restore()
 
 
   it 'should be a subclass of ember view', ->
@@ -57,3 +64,21 @@ describe 'track view', ->
       @trackView.drawTrack('M0,0Z')
 
       (expect @paperClearSpy).toHaveBeenCalled()
+
+  describe 'enable/disable car controls', ->
+
+    beforeEach ->
+      @gameControllerMock.onTouchMouseDown = sinon.spy()
+      @gameControllerMock.onTouchMouseUp = sinon.spy()
+
+    describe 'when controls are enabled', ->
+  
+      it 'should call onTouchMouseDown on game controller when controls are enabled', ->
+        @gameControllerMock.get = sinon.stub().withArgs('carControlsEnabled').returns true
+        @trackView.onCarControlsChange()
+
+        (jQuery @trackView.$()).trigger 'touchMouseDown'
+
+        (expect @gameControllerMock.onTouchMouseDown).toHaveBeenCalled()
+
+    describe 'when controls are disabled', ->


### PR DESCRIPTION
This commit adds some kind of 'starting lights'. At the moment this means: 3, .. 2, .. 1, .. Go!
The development of this feature also required to move the car control binding into the track view, so the car controls can now be en-/disabled by a flag on the game controller.
On my machine there are lags sometimes but it seems this is not the case on the iPad.
