### PR TITLE
fixes #99 delays rasterization a bit to display overlay faster

### DIFF
--- a/app/assets/javascripts/helpers/math/raphael_path.js.coffee
+++ b/app/assets/javascripts/helpers/math/raphael_path.js.coffee
@@ -52,9 +52,11 @@ RaphaelPath = helpers.math.RaphaelPath = Ember.Object.extend
     # stop immediately if total length is zero
     return if totalLength <= 0
 
-    stepSize = parameters.stepSize ?= 5
-    pointsPerTick = parameters.pointsPerTick ?= 50
-    currentStartLength = parameters.currentLength ?= 0
+    parameters.currentLength ?= 0
+
+    stepSize = parameters.stepSize
+    pointsPerTick = parameters.pointsPerTick
+    currentStartLength = parameters.currentLength
 
     # clamp next current length to total length
     currentEndLength = currentStartLength + pointsPerTick * stepSize

--- a/app/assets/javascripts/slotcars/shared/models/track.js.coffee
+++ b/app/assets/javascripts/slotcars/shared/models/track.js.coffee
@@ -51,12 +51,15 @@ slotcars.shared.models.Track = DS.Model.extend
 
   rasterize: (finishCallback) ->
     @set 'isRasterizing', true
-    (@get '_raphaelPath').rasterize
-      stepSize: 10
-      onProgress: ($.proxy @_onRasterizationProgress, this)
-      onFinished: =>
-        @set 'isRasterizing', false
-        finishCallback() if finishCallback?
+    Ember.run.later (=>
+      (@get '_raphaelPath').rasterize
+        stepSize: 10
+        pointsPerTick: 50
+        onProgress: ($.proxy @_onRasterizationProgress, this)
+        onFinished: =>
+          @set 'isRasterizing', false
+          finishCallback() if finishCallback?
+    ), 50
 
   cancelRasterization: ->
     (@get '_raphaelPath').cancelRasterization()

--- a/spec/javascripts/unit/slotcars/shared/models/track_spec.js.coffee
+++ b/spec/javascripts/unit/slotcars/shared/models/track_spec.js.coffee
@@ -166,8 +166,11 @@ describe 'slotcars.shared.models.Track', ->
       @RaphaelMock = window.Raphael =
         getSubpath: sinon.stub().returns @fakeRasterizedPathValue
 
+      @emberRunLaterStub = sinon.stub(Ember.run, 'later').yields()
+
     afterEach ->
       window.Raphael = @RaphaelBackup
+      @emberRunLaterStub.restore()
 
 
     it 'should not be rasterizing by default', ->
@@ -177,6 +180,11 @@ describe 'slotcars.shared.models.Track', ->
       @track.rasterize()
 
       (expect @track.get 'isRasterizing').toBe true
+
+    it 'should defer rasterization with ember', ->
+      @track.rasterize()
+
+      (expect @emberRunLaterStub).toHaveBeenCalledOnce()
 
     it 'should tell the raphael path to rasterize', ->
       @track.rasterize()


### PR DESCRIPTION
Adds a delay of 50 milliseconds before starting rasterization in the track model to wait for the rasterization overlay to appear on the unbelievable slow iPad. Yeah, I know - that's a hack because basically the model now adds logic that is there because of a certain aspect of the view. If someone has a better idea of how to do this - go on and tell me ;-)
