### PR TITLE
Bug/drawing track is jumpy

### DIFF
--- a/app/assets/javascripts/slotcars/build/controllers/draw_controller.js.coffee
+++ b/app/assets/javascripts/slotcars/build/controllers/draw_controller.js.coffee
@@ -1,15 +1,27 @@
 
 #= require helpers/namespace
+#= require helpers/math/vector
 
 namespace 'slotcars.build.controllers'
+
+ADD_POINT_MIN_DISTANCE = 30
 
 slotcars.build.controllers.DrawController = Ember.Object.extend
 
   track: null
   finishedDrawing: false
   isRasterizing: false
+  _lastAddedPoint: null
 
-  onTouchMouseMove: (point) -> @track.addPathPoint point unless @finishedDrawing
+  onTouchMouseMove: (point) ->
+    # only add new point if it is at least 40 pixels away from last
+    @_lastAddedPoint = { x: 0, y: 0 } unless @_lastAddedPoint?
+    distanceVector = helpers.math.Vector.create from: @_lastAddedPoint, to: point
+    @addPointToTrack point if distanceVector.length() > ADD_POINT_MIN_DISTANCE
+
+  addPointToTrack: (point) ->
+    @track.addPathPoint point
+    @_lastAddedPoint = point
 
   onClearTrack: ->
     @set 'finishedDrawing', false

--- a/app/assets/javascripts/slotcars/build/controllers/draw_controller.js.coffee
+++ b/app/assets/javascripts/slotcars/build/controllers/draw_controller.js.coffee
@@ -14,6 +14,7 @@ slotcars.build.controllers.DrawController = Ember.Object.extend
   _lastAddedPoint: null
 
   onTouchMouseMove: (point) ->
+    return if @finishedDrawing
     # only add new point if it is at least 40 pixels away from last
     @_lastAddedPoint = { x: 0, y: 0 } unless @_lastAddedPoint?
     distanceVector = helpers.math.Vector.create from: @_lastAddedPoint, to: point

--- a/spec/javascripts/unit/slotcars/build/controllers/draw_controller_spec.js.coffee
+++ b/spec/javascripts/unit/slotcars/build/controllers/draw_controller_spec.js.coffee
@@ -25,11 +25,17 @@ describe 'slotcars.build.controllers.DrawController', ->
 
   describe 'add path points to track model on mouse move', ->
 
-    it 'should accept a point and tell the track model to add it', ->
-      testPoint = x: 0, y: 0
+    it 'should add point to model if it has enough distance from last point', ->
+      testPoint = x: 9999, y: 0
       @drawController.onTouchMouseMove testPoint
 
       (expect @trackMock.addPathPoint).toHaveBeenCalledWith testPoint
+
+    it 'should not add point if it is too close to last added point', ->
+      testPoint = x: 1, y: 0
+      @drawController.onTouchMouseMove testPoint
+
+      (expect @trackMock.addPathPoint).not.toHaveBeenCalled()
 
     it 'should not add further points when user finished drawing', ->
       @drawController.finishedDrawing = true


### PR DESCRIPTION
Improves the drawing performance while building the track by reducing the number of points added to the track model (less calculations) and only drawing one path per update (less svg operations). This results in a smooth drawing experience even on iPad 1

The first optimization (less points added) also had a really positive side-effect of eliminating all artifacts and improving the accuracy of the cleaning algorithm to keep important detail.

have fun jerkin off!
