### PR TITLE
Chore/use ember namespaces

### DIFF
--- a/app/assets/javascripts/application.js.coffee
+++ b/app/assets/javascripts/application.js.coffee
@@ -1,6 +1,7 @@
 #= require jquery
 #= require jquery_ujs
 #= require embient/ember
+#= require helpers/namespace
 #= require slotcars/factories/screen_factory
 #= require slotcars/slotcars_application
 

--- a/app/assets/javascripts/helpers/graphic/exhaust.js.coffee
+++ b/app/assets/javascripts/helpers/graphic/exhaust.js.coffee
@@ -1,9 +1,5 @@
 
-#= require helpers/namespace
-
-namespace 'helpers.graphic'
-
-class helpers.graphic.Exhaust
+class namespace('helpers.graphic').Exhaust
   
   paper: null
   fumes: null

--- a/app/assets/javascripts/helpers/graphic/exhaust.js.coffee
+++ b/app/assets/javascripts/helpers/graphic/exhaust.js.coffee
@@ -1,5 +1,5 @@
 
-class namespace('helpers.graphic').Exhaust
+class (namespace 'helpers.graphic').Exhaust
   
   paper: null
   fumes: null

--- a/app/assets/javascripts/helpers/math/linked_list.js.coffee
+++ b/app/assets/javascripts/helpers/math/linked_list.js.coffee
@@ -1,9 +1,5 @@
 
-#= require helpers/namespace
-
-namespace 'helpers.math'
-
-class helpers.math.LinkedList
+class namespace('helpers.math').LinkedList
 
   head: null
   tail: null

--- a/app/assets/javascripts/helpers/math/linked_list.js.coffee
+++ b/app/assets/javascripts/helpers/math/linked_list.js.coffee
@@ -1,5 +1,5 @@
 
-class namespace('helpers.math').LinkedList
+class (namespace 'helpers.math').LinkedList
 
   head: null
   tail: null

--- a/app/assets/javascripts/helpers/math/path.js.coffee
+++ b/app/assets/javascripts/helpers/math/path.js.coffee
@@ -5,7 +5,7 @@
 Vector = helpers.math.Vector
 LinkedList = helpers.math.LinkedList
 
-class namespace('helpers.math').Path extends LinkedList
+class (namespace 'helpers.math').Path extends LinkedList
 
   totalLength: 0
   _lengthDirty: false

--- a/app/assets/javascripts/helpers/math/path.js.coffee
+++ b/app/assets/javascripts/helpers/math/path.js.coffee
@@ -1,14 +1,11 @@
 
-#= require helpers/namespace
 #= require helpers/math/vector
 #= require helpers/math/linked_list
-
-namespace 'helpers.math'
 
 Vector = helpers.math.Vector
 LinkedList = helpers.math.LinkedList
 
-class helpers.math.Path extends LinkedList
+class namespace('helpers.math').Path extends LinkedList
 
   totalLength: 0
   _lengthDirty: false

--- a/app/assets/javascripts/helpers/math/raphael_path.js.coffee
+++ b/app/assets/javascripts/helpers/math/raphael_path.js.coffee
@@ -1,15 +1,12 @@
 
-#= require helpers/namespace
 #= require helpers/math/path
 #= require vendor/raphael
-
-namespace 'helpers.math'
 
 EMPTY_RAPHAEL_PATH_STRING = 'M0,0z'
 
 Path = helpers.math.Path
 
-RaphaelPath = helpers.math.RaphaelPath = Ember.Object.extend
+RaphaelPath = namespace('helpers.math').RaphaelPath = Ember.Object.extend
 
   path: EMPTY_RAPHAEL_PATH_STRING
   _path: null

--- a/app/assets/javascripts/helpers/math/raphael_path.js.coffee
+++ b/app/assets/javascripts/helpers/math/raphael_path.js.coffee
@@ -6,7 +6,7 @@ EMPTY_RAPHAEL_PATH_STRING = 'M0,0z'
 
 Path = helpers.math.Path
 
-RaphaelPath = namespace('helpers.math').RaphaelPath = Ember.Object.extend
+RaphaelPath = (namespace 'helpers.math').RaphaelPath = Ember.Object.extend
 
   path: EMPTY_RAPHAEL_PATH_STRING
   _path: null

--- a/app/assets/javascripts/helpers/math/vector.js.coffee
+++ b/app/assets/javascripts/helpers/math/vector.js.coffee
@@ -1,5 +1,5 @@
 
-class namespace('helpers.math').Vector
+class (namespace 'helpers.math').Vector
 
   constructor: (@x, @y) ->
 

--- a/app/assets/javascripts/helpers/math/vector.js.coffee
+++ b/app/assets/javascripts/helpers/math/vector.js.coffee
@@ -1,9 +1,5 @@
 
-#= require helpers/namespace
-
-namespace 'helpers.math'
-
-class helpers.math.Vector
+class namespace('helpers.math').Vector
 
   constructor: (@x, @y) ->
 

--- a/app/assets/javascripts/helpers/namespace.js.coffee
+++ b/app/assets/javascripts/helpers/namespace.js.coffee
@@ -3,6 +3,8 @@
   namespaces = path.split '.'
   target = window
   
-  for namespace in namespaces
-    target[namespace] or= {} 
+  for namespace, index in namespaces
+    target[namespace] or= {}
     target = target[namespace]
+
+  return target

--- a/app/assets/javascripts/helpers/routing/route_local_links.js.coffee
+++ b/app/assets/javascripts/helpers/routing/route_local_links.js.coffee
@@ -1,9 +1,5 @@
 
-#= require helpers/namespace
-
-namespace 'helpers.routing'
-
-helpers.routing.routeLocalLinks = (routeManager) ->
+namespace('helpers.routing').routeLocalLinks = (routeManager) ->
 
   (jQuery 'a').live 'click', (event) ->
     href = (jQuery this).attr 'href'

--- a/app/assets/javascripts/helpers/routing/route_local_links.js.coffee
+++ b/app/assets/javascripts/helpers/routing/route_local_links.js.coffee
@@ -1,5 +1,5 @@
 
-namespace('helpers.routing').routeLocalLinks = (routeManager) ->
+(namespace 'helpers.routing').routeLocalLinks = (routeManager) ->
 
   (jQuery 'a').live 'click', (event) ->
     href = (jQuery this).attr 'href'

--- a/app/assets/javascripts/slotcars/build/build_screen.js.coffee
+++ b/app/assets/javascripts/slotcars/build/build_screen.js.coffee
@@ -1,13 +1,10 @@
 
-#= require helpers/namespace
 #= require slotcars/build/views/build_screen_view
 #= require slotcars/build/builder
 
-namespace 'slotcars.build'
-
 Builder = slotcars.build.Builder
 
-slotcars.build.BuildScreen = Ember.Object.extend
+namespace('slotcars.build').BuildScreen = Ember.Object.extend
 
   _buildScreenView: null
   _builder: null

--- a/app/assets/javascripts/slotcars/build/build_screen.js.coffee
+++ b/app/assets/javascripts/slotcars/build/build_screen.js.coffee
@@ -4,7 +4,7 @@
 
 Builder = slotcars.build.Builder
 
-namespace('slotcars.build').BuildScreen = Ember.Object.extend
+(namespace 'slotcars.build').BuildScreen = Ember.Object.extend
 
   _buildScreenView: null
   _builder: null

--- a/app/assets/javascripts/slotcars/build/builder.js.coffee
+++ b/app/assets/javascripts/slotcars/build/builder.js.coffee
@@ -1,15 +1,12 @@
 
-#= require helpers/namespace
 #= require slotcars/shared/models/track
 #= require slotcars/build/controllers/draw_controller
 #= require slotcars/build/views/draw_view
 
-namespace 'slotcars.build'
-
 DrawController = slotcars.build.controllers.DrawController
 DrawView = slotcars.build.views.DrawView
 
-slotcars.build.Builder = Ember.Object.extend
+namespace('slotcars.build').Builder = Ember.Object.extend
 
   track: null
   drawController: null

--- a/app/assets/javascripts/slotcars/build/builder.js.coffee
+++ b/app/assets/javascripts/slotcars/build/builder.js.coffee
@@ -6,7 +6,7 @@
 DrawController = slotcars.build.controllers.DrawController
 DrawView = slotcars.build.views.DrawView
 
-namespace('slotcars.build').Builder = Ember.Object.extend
+(namespace 'slotcars.build').Builder = Ember.Object.extend
 
   track: null
   drawController: null

--- a/app/assets/javascripts/slotcars/build/controllers/draw_controller.js.coffee
+++ b/app/assets/javascripts/slotcars/build/controllers/draw_controller.js.coffee
@@ -1,9 +1,5 @@
 
-#= require helpers/namespace
-
-namespace 'slotcars.build.controllers'
-
-slotcars.build.controllers.DrawController = Ember.Object.extend
+namespace('slotcars.build.controllers').DrawController = Ember.Object.extend
 
   track: null
   finishedDrawing: false

--- a/app/assets/javascripts/slotcars/build/views/build_screen_view.js.coffee
+++ b/app/assets/javascripts/slotcars/build/views/build_screen_view.js.coffee
@@ -2,7 +2,7 @@
 #= require embient/ember-layout
 #= require slotcars/build/templates/build_screen_view_template
 
-namespace('slotcars.build.views').BuildScreenView = Ember.View.extend
+(namespace 'slotcars.build.views').BuildScreenView = Ember.View.extend
 
   elementId: 'build-screen-view'
   templateName: 'slotcars_build_templates_build_screen_view_template'

--- a/app/assets/javascripts/slotcars/build/views/build_screen_view.js.coffee
+++ b/app/assets/javascripts/slotcars/build/views/build_screen_view.js.coffee
@@ -1,11 +1,8 @@
 
-#= require helpers/namespace
 #= require embient/ember-layout
 #= require slotcars/build/templates/build_screen_view_template
 
-namespace 'slotcars.build.views'
-
-slotcars.build.views.BuildScreenView = Ember.View.extend
+namespace('slotcars.build.views').BuildScreenView = Ember.View.extend
 
   elementId: 'build-screen-view'
   templateName: 'slotcars_build_templates_build_screen_view_template'

--- a/app/assets/javascripts/slotcars/build/views/draw_view.js.coffee
+++ b/app/assets/javascripts/slotcars/build/views/draw_view.js.coffee
@@ -1,14 +1,11 @@
 
-#= require helpers/namespace
 #= require slotcars/shared/views/track_view
 #= require slotcars/build/templates/draw_view_template
 #= require helpers/event_normalize
 
-namespace 'slotcars.build.views'
-
 PAPER_WRAPPER_ID = '#draw-view-paper'
 
-slotcars.build.views.DrawView = slotcars.shared.views.TrackView.extend
+namespace('slotcars.build.views').DrawView = slotcars.shared.views.TrackView.extend
 
   track: null
   drawController: null

--- a/app/assets/javascripts/slotcars/build/views/draw_view.js.coffee
+++ b/app/assets/javascripts/slotcars/build/views/draw_view.js.coffee
@@ -5,7 +5,7 @@
 
 PAPER_WRAPPER_ID = '#draw-view-paper'
 
-namespace('slotcars.build.views').DrawView = slotcars.shared.views.TrackView.extend
+(namespace 'slotcars.build.views').DrawView = slotcars.shared.views.TrackView.extend
 
   track: null
   drawController: null

--- a/app/assets/javascripts/slotcars/factories/screen_factory.js.coffee
+++ b/app/assets/javascripts/slotcars/factories/screen_factory.js.coffee
@@ -4,7 +4,7 @@
 #= require slotcars/tracks/tracks_screen
 #= require slotcars/home/home_screen
 
-namespace('slotcars.factories').ScreenFactory = Ember.Object.extend
+(namespace 'slotcars.factories').ScreenFactory = Ember.Object.extend
 
   getBuildScreen: -> slotcars.build.BuildScreen.create()
 

--- a/app/assets/javascripts/slotcars/factories/screen_factory.js.coffee
+++ b/app/assets/javascripts/slotcars/factories/screen_factory.js.coffee
@@ -1,13 +1,10 @@
 
-#= require helpers/namespace
 #= require slotcars/build/build_screen
 #= require slotcars/play/play_screen
 #= require slotcars/tracks/tracks_screen
 #= require slotcars/home/home_screen
 
-namespace 'slotcars.factories'
-
-slotcars.factories.ScreenFactory = Ember.Object.extend
+namespace('slotcars.factories').ScreenFactory = Ember.Object.extend
 
   getBuildScreen: -> slotcars.build.BuildScreen.create()
 

--- a/app/assets/javascripts/slotcars/home/home_screen.js.coffee
+++ b/app/assets/javascripts/slotcars/home/home_screen.js.coffee
@@ -1,10 +1,7 @@
 
-#= require helpers/namespace
 #= require slotcars/home/views/home_screen_view
 
-namespace 'slotcars.home'
-
-slotcars.home.HomeScreen = Ember.Object.extend
+namespace('slotcars.home').HomeScreen = Ember.Object.extend
 
   _homeScreenView: null
 

--- a/app/assets/javascripts/slotcars/home/home_screen.js.coffee
+++ b/app/assets/javascripts/slotcars/home/home_screen.js.coffee
@@ -1,7 +1,7 @@
 
 #= require slotcars/home/views/home_screen_view
 
-namespace('slotcars.home').HomeScreen = Ember.Object.extend
+(namespace 'slotcars.home').HomeScreen = Ember.Object.extend
 
   _homeScreenView: null
 

--- a/app/assets/javascripts/slotcars/home/views/home_screen_view.js.coffee
+++ b/app/assets/javascripts/slotcars/home/views/home_screen_view.js.coffee
@@ -1,10 +1,7 @@
 
-#= require helpers/namespace
 #= require slotcars/home/templates/home_screen_view_template
 
-namespace 'slotcars.home.views'
-
-slotcars.home.views.HomeScreenView = Ember.View.extend
+namespace('slotcars.home.views').HomeScreenView = Ember.View.extend
 
   elementId: 'home_screen_view'
   templateName: 'slotcars_home_templates_home_screen_view_template'

--- a/app/assets/javascripts/slotcars/home/views/home_screen_view.js.coffee
+++ b/app/assets/javascripts/slotcars/home/views/home_screen_view.js.coffee
@@ -1,7 +1,7 @@
 
 #= require slotcars/home/templates/home_screen_view_template
 
-namespace('slotcars.home.views').HomeScreenView = Ember.View.extend
+(namespace 'slotcars.home.views').HomeScreenView = Ember.View.extend
 
   elementId: 'home_screen_view'
   templateName: 'slotcars_home_templates_home_screen_view_template'

--- a/app/assets/javascripts/slotcars/play/controllers/game_controller.js.coffee
+++ b/app/assets/javascripts/slotcars/play/controllers/game_controller.js.coffee
@@ -9,7 +9,7 @@ Car = slotcars.shared.models.Car
 CarView = slotcars.play.views.CarView
 GameLoopController = slotcars.play.controllers.GameLoopController
 
-namespace('slotcars.play.controllers').GameController = Ember.Object.extend
+(namespace 'slotcars.play.controllers').GameController = Ember.Object.extend
 
   car: null
   track: null

--- a/app/assets/javascripts/slotcars/play/controllers/game_controller.js.coffee
+++ b/app/assets/javascripts/slotcars/play/controllers/game_controller.js.coffee
@@ -5,13 +5,11 @@
 
 #= require helpers/event_normalize
 
-namespace 'slotcars.play.controllers'
-
 Car = slotcars.shared.models.Car
 CarView = slotcars.play.views.CarView
 GameLoopController = slotcars.play.controllers.GameLoopController
 
-slotcars.play.controllers.GameController = Ember.Object.extend
+namespace('slotcars.play.controllers').GameController = Ember.Object.extend
 
   car: null
   track: null

--- a/app/assets/javascripts/slotcars/play/controllers/game_loop_controller.js.coffee
+++ b/app/assets/javascripts/slotcars/play/controllers/game_loop_controller.js.coffee
@@ -1,7 +1,7 @@
 
 #= require helpers/request_frame
 
-namespace('slotcars.play.controllers').GameLoopController = Ember.Object.extend
+(namespace 'slotcars.play.controllers').GameLoopController = Ember.Object.extend
 
   renderCallback: null
 

--- a/app/assets/javascripts/slotcars/play/controllers/game_loop_controller.js.coffee
+++ b/app/assets/javascripts/slotcars/play/controllers/game_loop_controller.js.coffee
@@ -1,9 +1,7 @@
+
 #= require helpers/request_frame
-#= require helpers/namespace
 
-namespace 'slotcars.play.controllers'
-
-slotcars.play.controllers.GameLoopController = Ember.Object.extend
+namespace('slotcars.play.controllers').GameLoopController = Ember.Object.extend
 
   renderCallback: null
 

--- a/app/assets/javascripts/slotcars/play/game.js.coffee
+++ b/app/assets/javascripts/slotcars/play/game.js.coffee
@@ -1,13 +1,10 @@
 
-#= require helpers/namespace
 #= require slotcars/shared/models/car
 #= require slotcars/play/views/car_view
 #= require slotcars/play/views/game_view
 #= require slotcars/play/views/clock_view
 #= require slotcars/play/views/play_track_view
 #= require slotcars/play/controllers/game_controller
-
-namespace 'slotcars.play'
 
 GameController = slotcars.play.controllers.GameController
 CarView = slotcars.play.views.CarView
@@ -16,7 +13,7 @@ ClockView = slotcars.play.views.ClockView
 Car = slotcars.shared.models.Car
 PlayTrackView = slotcars.play.views.PlayTrackView
 
-slotcars.play.Game = Ember.Object.extend
+namespace('slotcars.play').Game = Ember.Object.extend
 
   playScreenView: null
   track: null

--- a/app/assets/javascripts/slotcars/play/game.js.coffee
+++ b/app/assets/javascripts/slotcars/play/game.js.coffee
@@ -13,7 +13,7 @@ ClockView = slotcars.play.views.ClockView
 Car = slotcars.shared.models.Car
 PlayTrackView = slotcars.play.views.PlayTrackView
 
-namespace('slotcars.play').Game = Ember.Object.extend
+(namespace 'slotcars.play').Game = Ember.Object.extend
 
   playScreenView: null
   track: null

--- a/app/assets/javascripts/slotcars/play/play_screen.js.coffee
+++ b/app/assets/javascripts/slotcars/play/play_screen.js.coffee
@@ -1,13 +1,10 @@
 
-#= require helpers/namespace
 #= require slotcars/play/views/play_screen_view
 #= require slotcars/play/play_screen_state_manager
 #= require slotcars/shared/models/track
 #= require slotcars/shared/models/model_store
 #= require slotcars/shared/models/car
 #= require slotcars/play/game
-
-namespace 'slotcars.play'
 
 ModelStore = slotcars.shared.models.ModelStore
 Track = slotcars.shared.models.Track
@@ -16,7 +13,7 @@ PlayScreenStateManager = slotcars.play.PlayScreenStateManager
 Car = slotcars.shared.models.Car
 Game = slotcars.play.Game
 
-slotcars.play.PlayScreen = Ember.Object.extend
+namespace('slotcars.play').PlayScreen = Ember.Object.extend
 
   trackId: null
   _playScreenView: null

--- a/app/assets/javascripts/slotcars/play/play_screen.js.coffee
+++ b/app/assets/javascripts/slotcars/play/play_screen.js.coffee
@@ -13,7 +13,7 @@ PlayScreenStateManager = slotcars.play.PlayScreenStateManager
 Car = slotcars.shared.models.Car
 Game = slotcars.play.Game
 
-namespace('slotcars.play').PlayScreen = Ember.Object.extend
+(namespace 'slotcars.play').PlayScreen = Ember.Object.extend
 
   trackId: null
   _playScreenView: null

--- a/app/assets/javascripts/slotcars/play/play_screen_state_manager.js.coffee
+++ b/app/assets/javascripts/slotcars/play/play_screen_state_manager.js.coffee
@@ -1,9 +1,5 @@
 
-#= require helpers/namespace
-
-namespace 'slotcars.play'
-
-slotcars.play.PlayScreenStateManager = Ember.StateManager.extend
+namespace('slotcars.play').PlayScreenStateManager = Ember.StateManager.extend
 
   initialState: 'Loading'
   delegate: null

--- a/app/assets/javascripts/slotcars/play/play_screen_state_manager.js.coffee
+++ b/app/assets/javascripts/slotcars/play/play_screen_state_manager.js.coffee
@@ -1,5 +1,5 @@
 
-namespace('slotcars.play').PlayScreenStateManager = Ember.StateManager.extend
+(namespace 'slotcars.play').PlayScreenStateManager = Ember.StateManager.extend
 
   initialState: 'Loading'
   delegate: null

--- a/app/assets/javascripts/slotcars/play/views/car_view.js.coffee
+++ b/app/assets/javascripts/slotcars/play/views/car_view.js.coffee
@@ -2,7 +2,7 @@
 #= require helpers/graphic/exhaust
 #= require slotcars/play/templates/car_view_template
 
-namespace('slotcars.play.views').CarView = Ember.View.extend
+(namespace 'slotcars.play.views').CarView = Ember.View.extend
 
   templateName: 'slotcars_play_templates_car_view_template'
   tagName: ''

--- a/app/assets/javascripts/slotcars/play/views/car_view.js.coffee
+++ b/app/assets/javascripts/slotcars/play/views/car_view.js.coffee
@@ -1,11 +1,8 @@
 
-#= require helpers/namespace
 #= require helpers/graphic/exhaust
 #= require slotcars/play/templates/car_view_template
 
-namespace 'slotcars.play.views'
-
-slotcars.play.views.CarView = Ember.View.extend
+namespace('slotcars.play.views').CarView = Ember.View.extend
 
   templateName: 'slotcars_play_templates_car_view_template'
   tagName: ''

--- a/app/assets/javascripts/slotcars/play/views/clock_view.js.coffee
+++ b/app/assets/javascripts/slotcars/play/views/clock_view.js.coffee
@@ -1,7 +1,7 @@
 
 #= require slotcars/play/templates/clock_view_template
 
-namespace('slotcars.play.views').ClockView = Ember.View.extend
+(namespace 'slotcars.play.views').ClockView = Ember.View.extend
 
   elementId: 'clock'
   templateName: 'slotcars_play_templates_clock_view_template'

--- a/app/assets/javascripts/slotcars/play/views/clock_view.js.coffee
+++ b/app/assets/javascripts/slotcars/play/views/clock_view.js.coffee
@@ -1,9 +1,7 @@
-#= require helpers/namespace
+
 #= require slotcars/play/templates/clock_view_template
 
-namespace 'slotcars.play.views'
-
-slotcars.play.views.ClockView = Ember.View.extend
+namespace('slotcars.play.views').ClockView = Ember.View.extend
 
   elementId: 'clock'
   templateName: 'slotcars_play_templates_clock_view_template'

--- a/app/assets/javascripts/slotcars/play/views/game_view.js.coffee
+++ b/app/assets/javascripts/slotcars/play/views/game_view.js.coffee
@@ -1,10 +1,7 @@
 
-#= require helpers/namespace
 #= require slotcars/play/templates/game_view_template
 
-namespace 'slotcars.play.views'
-
-slotcars.play.views.GameView = Ember.View.extend
+namespace('slotcars.play.views').GameView = Ember.View.extend
 
   elementId: 'game-view'
   templateName: 'slotcars_play_templates_game_view_template'

--- a/app/assets/javascripts/slotcars/play/views/game_view.js.coffee
+++ b/app/assets/javascripts/slotcars/play/views/game_view.js.coffee
@@ -1,7 +1,7 @@
 
 #= require slotcars/play/templates/game_view_template
 
-namespace('slotcars.play.views').GameView = Ember.View.extend
+(namespace 'slotcars.play.views').GameView = Ember.View.extend
 
   elementId: 'game-view'
   templateName: 'slotcars_play_templates_game_view_template'

--- a/app/assets/javascripts/slotcars/play/views/play_screen_view.js.coffee
+++ b/app/assets/javascripts/slotcars/play/views/play_screen_view.js.coffee
@@ -1,7 +1,7 @@
 
 #= require slotcars/play/templates/play_screen_view_template
 
-namespace('slotcars.play.views').PlayScreenView = Ember.View.extend
+(namespace 'slotcars.play.views').PlayScreenView = Ember.View.extend
 
   elementId: 'play-screen-view'
   templateName: 'slotcars_play_templates_play_screen_view_template'

--- a/app/assets/javascripts/slotcars/play/views/play_screen_view.js.coffee
+++ b/app/assets/javascripts/slotcars/play/views/play_screen_view.js.coffee
@@ -1,10 +1,7 @@
 
-#= require helpers/namespace
 #= require slotcars/play/templates/play_screen_view_template
 
-namespace 'slotcars.play.views'
-
-slotcars.play.views.PlayScreenView = Ember.View.extend
+namespace('slotcars.play.views').PlayScreenView = Ember.View.extend
 
   elementId: 'play-screen-view'
   templateName: 'slotcars_play_templates_play_screen_view_template'

--- a/app/assets/javascripts/slotcars/play/views/play_track_view.js.coffee.erb
+++ b/app/assets/javascripts/slotcars/play/views/play_track_view.js.coffee.erb
@@ -1,14 +1,11 @@
 
-#= require helpers/namespace
 #= require helpers/event_normalize
 #= require slotcars/shared/views/track_view
 #= require helpers/math/vector
 
-namespace 'slotcars.play.views'
-
 Vector = helpers.math.Vector
 
-slotcars.play.views.PlayTrackView = slotcars.shared.views.TrackView.extend
+namespace('slotcars.play.views').PlayTrackView = slotcars.shared.views.TrackView.extend
 
   gameController: null
   

--- a/app/assets/javascripts/slotcars/route_manager.js.coffee
+++ b/app/assets/javascripts/slotcars/route_manager.js.coffee
@@ -1,9 +1,7 @@
-#= require helpers/namespace
+
 #= require embient/ember-routemanager
 
-namespace 'slotcars'
-
-slotcars.RouteManager = Ember.RouteManager.extend
+namespace('slotcars').RouteManager = Ember.RouteManager.extend
 
   wantsHistory: true # use html5 push state
   delegate: null

--- a/app/assets/javascripts/slotcars/route_manager.js.coffee
+++ b/app/assets/javascripts/slotcars/route_manager.js.coffee
@@ -1,7 +1,7 @@
 
 #= require embient/ember-routemanager
 
-namespace('slotcars').RouteManager = Ember.RouteManager.extend
+(namespace 'slotcars').RouteManager = Ember.RouteManager.extend
 
   wantsHistory: true # use html5 push state
   delegate: null

--- a/app/assets/javascripts/slotcars/shared/lib/crashable.js.coffee
+++ b/app/assets/javascripts/slotcars/shared/lib/crashable.js.coffee
@@ -5,7 +5,7 @@
 Vector = helpers.math.Vector
 Movable = slotcars.shared.lib.Movable
 
-namespace('slotcars.shared.lib').Crashable = Ember.Mixin.create
+(namespace 'slotcars.shared.lib').Crashable = Ember.Mixin.create
 
   previousDirection: null
   isCrashing: false

--- a/app/assets/javascripts/slotcars/shared/lib/crashable.js.coffee
+++ b/app/assets/javascripts/slotcars/shared/lib/crashable.js.coffee
@@ -1,14 +1,11 @@
 
-#= require helpers/namespace
 #= require helpers/math/vector
 #= require slotcars/shared/lib/movable
-
-namespace 'slotcars.shared.lib'
 
 Vector = helpers.math.Vector
 Movable = slotcars.shared.lib.Movable
 
-slotcars.shared.lib.Crashable = Ember.Mixin.create
+namespace('slotcars.shared.lib').Crashable = Ember.Mixin.create
 
   previousDirection: null
   isCrashing: false

--- a/app/assets/javascripts/slotcars/shared/lib/movable.js.coffee
+++ b/app/assets/javascripts/slotcars/shared/lib/movable.js.coffee
@@ -1,12 +1,9 @@
 
-#= require helpers/namespace
 #= require helpers/math/vector
-
-namespace 'slotcars.shared.lib'
 
 Vector = helpers.math.Vector
 
-slotcars.shared.lib.Movable = Ember.Mixin.create
+namespace('slotcars.shared.lib').Movable = Ember.Mixin.create
 
   position: x: 0, y: 0
   rotation: 0

--- a/app/assets/javascripts/slotcars/shared/lib/movable.js.coffee
+++ b/app/assets/javascripts/slotcars/shared/lib/movable.js.coffee
@@ -3,7 +3,7 @@
 
 Vector = helpers.math.Vector
 
-namespace('slotcars.shared.lib').Movable = Ember.Mixin.create
+(namespace 'slotcars.shared.lib').Movable = Ember.Mixin.create
 
   position: x: 0, y: 0
   rotation: 0

--- a/app/assets/javascripts/slotcars/shared/models/car.js.coffee
+++ b/app/assets/javascripts/slotcars/shared/models/car.js.coffee
@@ -1,16 +1,13 @@
 
-#= require helpers/namespace
 #= require helpers/math/vector
 
 #= require slotcars/shared/lib/movable
 #= require slotcars/shared/lib/crashable
 
-namespace 'slotcars.shared.models'
-
 Movable = slotcars.shared.lib.Movable
 Crashable = slotcars.shared.lib.Crashable
 
-slotcars.shared.models.Car = Ember.Object.extend Movable, Crashable,
+namespace('slotcars.shared.models').Car = Ember.Object.extend Movable, Crashable,
 
   speed: 0
   maxSpeed: 0

--- a/app/assets/javascripts/slotcars/shared/models/car.js.coffee
+++ b/app/assets/javascripts/slotcars/shared/models/car.js.coffee
@@ -7,7 +7,7 @@
 Movable = slotcars.shared.lib.Movable
 Crashable = slotcars.shared.lib.Crashable
 
-namespace('slotcars.shared.models').Car = Ember.Object.extend Movable, Crashable,
+(namespace 'slotcars.shared.models').Car = Ember.Object.extend Movable, Crashable,
 
   speed: 0
   maxSpeed: 0

--- a/app/assets/javascripts/slotcars/shared/models/model_store.js.coffee
+++ b/app/assets/javascripts/slotcars/shared/models/model_store.js.coffee
@@ -1,8 +1,5 @@
 
-#= require helpers/namespace
 #= require embient/ember-data
 
-namespace 'slotcars.shared.models'
-
-slotcars.shared.models.ModelStore = DS.Store.create
+namespace('slotcars.shared.models').ModelStore = DS.Store.create
   adapter: DS.RESTAdapter.create()

--- a/app/assets/javascripts/slotcars/shared/models/model_store.js.coffee
+++ b/app/assets/javascripts/slotcars/shared/models/model_store.js.coffee
@@ -1,5 +1,5 @@
 
 #= require embient/ember-data
 
-namespace('slotcars.shared.models').ModelStore = DS.Store.create
+(namespace 'slotcars.shared.models').ModelStore = DS.Store.create
   adapter: DS.RESTAdapter.create()

--- a/app/assets/javascripts/slotcars/shared/models/track.js.coffee
+++ b/app/assets/javascripts/slotcars/shared/models/track.js.coffee
@@ -6,7 +6,7 @@
 
 RaphaelPath = helpers.math.RaphaelPath
 
-namespace('slotcars.shared.models').Track = DS.Model.extend
+(namespace 'slotcars.shared.models').Track = DS.Model.extend
 
   _raphaelPath: null
   raphaelPathBinding: '_raphaelPath.path'

--- a/app/assets/javascripts/slotcars/shared/models/track.js.coffee
+++ b/app/assets/javascripts/slotcars/shared/models/track.js.coffee
@@ -1,15 +1,12 @@
 
-#= require helpers/namespace
 #= require embient/ember-data
 #= require slotcars/shared/models/model_store
 #= require helpers/math/raphael_path
 #= require vendor/raphael
 
-namespace 'slotcars.shared.models'
-
 RaphaelPath = helpers.math.RaphaelPath
 
-slotcars.shared.models.Track = DS.Model.extend
+namespace('slotcars.shared.models').Track = DS.Model.extend
 
   _raphaelPath: null
   raphaelPathBinding: '_raphaelPath.path'

--- a/app/assets/javascripts/slotcars/shared/views/track_view.js.coffee
+++ b/app/assets/javascripts/slotcars/shared/views/track_view.js.coffee
@@ -3,7 +3,7 @@
 
 Vector = helpers.math.Vector
 
-namespace('slotcars.shared.views').TrackView = Ember.View.extend
+(namespace 'slotcars.shared.views').TrackView = Ember.View.extend
 
   elementId: 'track-view'
   track: null

--- a/app/assets/javascripts/slotcars/shared/views/track_view.js.coffee
+++ b/app/assets/javascripts/slotcars/shared/views/track_view.js.coffee
@@ -1,12 +1,9 @@
 
-#= require helpers/namespace
 #= require vendor/raphael
-
-namespace 'slotcars.shared.views'
 
 Vector = helpers.math.Vector
 
-slotcars.shared.views.TrackView = Ember.View.extend
+namespace('slotcars.shared.views').TrackView = Ember.View.extend
 
   elementId: 'track-view'
   track: null

--- a/app/assets/javascripts/slotcars/slotcars_application.js.coffee
+++ b/app/assets/javascripts/slotcars/slotcars_application.js.coffee
@@ -1,10 +1,8 @@
-#= require helpers/namespace
+
 #= require slotcars/route_manager
 #= require helpers/routing/route_local_links
 
-namespace 'slotcars'
-
-slotcars.SlotcarsApplication = Ember.Application.extend
+namespace('slotcars').SlotcarsApplication = Ember.Application.extend
   screenFactory: null
   _currentScreen: null
 

--- a/app/assets/javascripts/slotcars/slotcars_application.js.coffee
+++ b/app/assets/javascripts/slotcars/slotcars_application.js.coffee
@@ -2,7 +2,7 @@
 #= require slotcars/route_manager
 #= require helpers/routing/route_local_links
 
-namespace('slotcars').SlotcarsApplication = Ember.Application.extend
+(namespace 'slotcars').SlotcarsApplication = Ember.Application.extend
   screenFactory: null
   _currentScreen: null
 

--- a/app/assets/javascripts/slotcars/tracks/controllers/tracks_controller.js.coffee
+++ b/app/assets/javascripts/slotcars/tracks/controllers/tracks_controller.js.coffee
@@ -1,2 +1,2 @@
 
-namespace('slotcars.tracks.controllers').TracksController = Ember.Object.extend()
+(namespace 'slotcars.tracks.controllers').TracksController = Ember.Object.extend()

--- a/app/assets/javascripts/slotcars/tracks/controllers/tracks_controller.js.coffee
+++ b/app/assets/javascripts/slotcars/tracks/controllers/tracks_controller.js.coffee
@@ -1,6 +1,2 @@
 
-#= require helpers/namespace
-
-namespace 'slotcars.tracks.controllers'
-
-slotcars.tracks.controllers.TracksController = Ember.Object.extend()
+namespace('slotcars.tracks.controllers').TracksController = Ember.Object.extend()

--- a/app/assets/javascripts/slotcars/tracks/tracks_screen.js.coffee
+++ b/app/assets/javascripts/slotcars/tracks/tracks_screen.js.coffee
@@ -5,7 +5,7 @@
 TracksController = slotcars.tracks.controllers.TracksController
 TracksScreenView = slotcars.tracks.views.TracksScreenView
 
-namespace('slotcars.tracks').TracksScreen = Ember.Object.extend
+(namespace 'slotcars.tracks').TracksScreen = Ember.Object.extend
 
   appendToApplication: ->
     TracksController.create()

--- a/app/assets/javascripts/slotcars/tracks/tracks_screen.js.coffee
+++ b/app/assets/javascripts/slotcars/tracks/tracks_screen.js.coffee
@@ -1,14 +1,11 @@
 
-#= require helpers/namespace
 #= require slotcars/tracks/controllers/tracks_controller
 #= require slotcars/tracks/views/tracks_screen_view
-
-namespace 'slotcars.tracks'
 
 TracksController = slotcars.tracks.controllers.TracksController
 TracksScreenView = slotcars.tracks.views.TracksScreenView
 
-slotcars.tracks.TracksScreen = Ember.Object.extend
+namespace('slotcars.tracks').TracksScreen = Ember.Object.extend
 
   appendToApplication: ->
     TracksController.create()

--- a/app/assets/javascripts/slotcars/tracks/views/tracks_screen_view.js.coffee
+++ b/app/assets/javascripts/slotcars/tracks/views/tracks_screen_view.js.coffee
@@ -1,10 +1,7 @@
 
-#= require helpers/namespace
 #= require slotcars/tracks/templates/tracks_screen_view_template
 
-namespace 'slotcars.tracks.views'
-
-slotcars.tracks.views.TracksScreenView = Ember.View.extend
+namespace('slotcars.tracks.views').TracksScreenView = Ember.View.extend
 
   elementId: 'tracks-screen-view'
   templateName: 'slotcars_tracks_templates_tracks_screen_view_template'

--- a/app/assets/javascripts/slotcars/tracks/views/tracks_screen_view.js.coffee
+++ b/app/assets/javascripts/slotcars/tracks/views/tracks_screen_view.js.coffee
@@ -1,7 +1,7 @@
 
 #= require slotcars/tracks/templates/tracks_screen_view_template
 
-namespace('slotcars.tracks.views').TracksScreenView = Ember.View.extend
+(namespace 'slotcars.tracks.views').TracksScreenView = Ember.View.extend
 
   elementId: 'tracks-screen-view'
   templateName: 'slotcars_tracks_templates_tracks_screen_view_template'

--- a/spec/javascripts/spec.js.coffee
+++ b/spec/javascripts/spec.js.coffee
@@ -11,6 +11,7 @@
 #= require sinon
 #= require jasmine-sinon
 #= require_tree ./helpers
+#= require helpers/namespace
 
 # ------ load all specs ------
 #= require_tree ./unit

--- a/spec/javascripts/unit/helpers/namespace_spec.js.coffee
+++ b/spec/javascripts/unit/helpers/namespace_spec.js.coffee
@@ -3,7 +3,8 @@
 
 describe 'namespace', ->
   
-  it 'should create nested objects for namespace string', ->
-    namespace('nested.objects.test')
-    
-    (expect nested.objects.test).toEqual {}
+  it 'should create and return nested objects for namespace string', ->
+    returnValue = namespace 'nested.name.space.last'
+
+    (expect nested.name.space.last).toEqual {}
+    (expect returnValue).toBe nested.name.space.last


### PR DESCRIPTION
Improves the namespace function to return the last part of the namespace so the classes etc. can be directly assigned to the return value.

It looks kind of frightening because all files / classes in the project have been changed to use the new namespacing technique.

the upside is approx. 3 lines less per file and less repeating yourself! :-)
