### PR TITLE
Pull Request: feature/choose sepecfic track

### DIFF
--- a/app/assets/javascripts/slotcars/play/play_screen.js.coffee
+++ b/app/assets/javascripts/slotcars/play/play_screen.js.coffee
@@ -32,7 +32,7 @@ Game = slotcars.play.Game
     @_playScreenView.remove()
 
   load: ->
-    @track = ModelStore.findByClientId Track, @trackId
+    @track = ModelStore.find Track, @trackId
 
     @car = Car.create
       acceleration: 0.1

--- a/app/assets/javascripts/slotcars/shared/views/thumbnail_track_view.js.coffee
+++ b/app/assets/javascripts/slotcars/shared/views/thumbnail_track_view.js.coffee
@@ -7,3 +7,6 @@ TrackView = slotcars.shared.views.TrackView
   
   scaleFactor: 0.3
   drawTrackOnDidInsertElement: true
+
+  click: ->
+    slotcars.routeManager.set 'location', "play/#{@track.get 'id'}"

--- a/app/assets/javascripts/slotcars/shared/views/thumbnail_track_view.js.coffee
+++ b/app/assets/javascripts/slotcars/shared/views/thumbnail_track_view.js.coffee
@@ -8,5 +8,7 @@ TrackView = slotcars.shared.views.TrackView
   scaleFactor: 0.3
   drawTrackOnDidInsertElement: true
 
-  click: ->
-    slotcars.routeManager.set 'location', "play/#{@track.get 'id'}"
+  didInsertElement: ->
+    @_super()
+
+    @$().on 'touchMouseUp', => slotcars.routeManager.set 'location', "play/#{@track.get 'id'}"

--- a/spec/javascripts/unit/slotcars/play/play_screen_spec.js.coffee
+++ b/spec/javascripts/unit/slotcars/play/play_screen_spec.js.coffee
@@ -4,6 +4,7 @@
 #= require slotcars/play/play_screen_state_manager
 #= require slotcars/shared/models/track
 #= require slotcars/play/game
+#= require slotcars/shared/models/model_store
 
 describe 'play screen', ->
 
@@ -13,14 +14,18 @@ describe 'play screen', ->
   Track = slotcars.shared.models.Track
   Car = slotcars.shared.models.Car
   Game = slotcars.play.Game
+  ModelStore = slotcars.shared.models.ModelStore
 
   beforeEach ->
+    sinon.stub ModelStore, 'find', -> Track.createRecord()
+
     @playScreenViewMock = mockEmberClass PlayScreenView, append: sinon.spy()
     @playScreenStateManagerMock = mockEmberClass PlayScreenStateManager, send: sinon.spy()
     @GameMock = mockEmberClass Game, start: sinon.spy()
     @playScreen = PlayScreen.create()
 
   afterEach ->
+    ModelStore.find.restore()
     @playScreenViewMock.restore()
     @playScreenStateManagerMock.restore()
     @GameMock.restore()


### PR DESCRIPTION
If you click on a track in the tracks screen the track is loaded and you can start playing.

Note: This feature breaks the "Test" button in the build screen because instead of the client id we have to use the real persistent id.
