### PR TITLE
Pull Request: bug/tidyup-game

### DIFF
--- a/app/assets/javascripts/slotcars/play/controllers/game_controller.js.coffee
+++ b/app/assets/javascripts/slotcars/play/controllers/game_controller.js.coffee
@@ -132,3 +132,12 @@ GameLoopController = slotcars.play.controllers.GameLoopController
     @endTime = new Date().getTime()
     if @get 'carControlsEnabled'
       @set 'raceTime', @endTime - @startTime
+
+  destroy: ->
+    # clear all timeouts
+    @_clearTimeouts()
+
+    # force unbinding of car controls
+    @set 'carControlsEnabled', false
+
+    @gameLoopController.destroy()

--- a/app/assets/javascripts/slotcars/play/controllers/game_loop_controller.js.coffee
+++ b/app/assets/javascripts/slotcars/play/controllers/game_loop_controller.js.coffee
@@ -4,10 +4,18 @@
 (namespace 'slotcars.play.controllers').GameLoopController = Ember.Object.extend
 
   renderCallback: null
+  stopLoop: false
 
   start: (@renderCallback) ->
+    @stopLoop = false
+
     @_run()
 
   _run: ->
+    return if @stopLoop
+
     window.requestFrame => @_run()
     @renderCallback()
+
+  destroy: ->
+    @stopLoop = true

--- a/app/assets/javascripts/slotcars/play/game.js.coffee
+++ b/app/assets/javascripts/slotcars/play/game.js.coffee
@@ -42,3 +42,6 @@ PlayTrackView = slotcars.play.views.PlayTrackView
     @playScreenView.set 'carView', @_carView
     @playScreenView.set 'gameView', @_gameView
     @playScreenView.set 'clockView', @_clockView
+
+  destroy: ->
+    @_gameController.destroy()

--- a/app/assets/javascripts/slotcars/play/play_screen.js.coffee
+++ b/app/assets/javascripts/slotcars/play/play_screen.js.coffee
@@ -30,6 +30,7 @@ Game = slotcars.play.Game
   destroy: ->
     @_super()
     @_playScreenView.remove()
+    @_game.destroy() if @_game?
 
   load: ->
     @track = ModelStore.find Track, @trackId

--- a/spec/javascripts/unit/slotcars/play/controllers/game_controller_spec.js.coffee
+++ b/spec/javascripts/unit/slotcars/play/controllers/game_controller_spec.js.coffee
@@ -373,3 +373,14 @@ describe 'slotcars.play.controllers.GameController (unit)', ->
       (expect @gameController.lapTimes.length).toBe 0
 
       fakeTimer.restore()
+
+  describe 'destroy', ->
+
+    it 'should call destroy of the game loop controller', ->
+      gameLoopControllerStub =
+        destroy: sinon.spy()
+
+      @gameController.set 'gameLoopController', gameLoopControllerStub
+      @gameController.destroy()
+
+      (expect gameLoopControllerStub.destroy).toHaveBeenCalled()

--- a/spec/javascripts/unit/slotcars/play/controllers/game_loop_controller_spec.js.coffee
+++ b/spec/javascripts/unit/slotcars/play/controllers/game_loop_controller_spec.js.coffee
@@ -22,6 +22,12 @@ describe 'slotcars.play.controllers.GameLoopController (unit)', ->
 
       (expect renderCallbackSpy).toHaveBeenCalled()
 
+    it 'should set the stop loop flag to false', ->
+      @gameLoop.set 'stopLoop', true
+      @gameLoop.start ->
+
+      (expect @gameLoop.get 'stopLoop').toBe false
+
     it 'should use requestFrame for running the loop', ->
       @gameLoop.start ->
 
@@ -41,3 +47,21 @@ describe 'slotcars.play.controllers.GameLoopController (unit)', ->
       @gameLoop.start renderCallbackSpy
 
       (expect renderCallbackSpy).toHaveBeenCalledThrice()
+
+    it 'should stop the loop if the stop loop flag is set', ->
+      count = 0
+      callback = -> count++
+
+      @gameLoop.start callback
+
+      numberOfCalls = count
+      @gameLoop.set 'stopLoop', true
+
+      (expect count).toEqual numberOfCalls
+
+  describe '#destroy', ->
+
+    it 'should set the stop loop flag to true', ->
+      @gameLoop.destroy()
+
+      (expect @gameLoop.get 'stopLoop').toBe true

--- a/spec/javascripts/unit/slotcars/play/game_spec.js.coffee
+++ b/spec/javascripts/unit/slotcars/play/game_spec.js.coffee
@@ -92,3 +92,11 @@ describe 'game', ->
       @game.start()
 
       (expect @GameControllerMock.start).toHaveBeenCalled()
+
+  describe 'destroying the game', ->
+
+    it 'should call destroy on the game controller', ->
+      @GameControllerMock.destroy = sinon.spy()
+      @game.destroy()
+
+      (expect @GameControllerMock.destroy).toHaveBeenCalled()

--- a/spec/javascripts/unit/slotcars/play/play_screen_spec.js.coffee
+++ b/spec/javascripts/unit/slotcars/play/play_screen_spec.js.coffee
@@ -21,7 +21,10 @@ describe 'play screen', ->
 
     @playScreenViewMock = mockEmberClass PlayScreenView, append: sinon.spy()
     @playScreenStateManagerMock = mockEmberClass PlayScreenStateManager, send: sinon.spy()
-    @GameMock = mockEmberClass Game, start: sinon.spy()
+    @GameMock = mockEmberClass Game,
+      start: sinon.spy()
+      destroy: sinon.spy()
+
     @playScreen = PlayScreen.create()
 
   afterEach ->
@@ -93,14 +96,26 @@ describe 'play screen', ->
     it 'should start the game', ->
       (expect @GameMock.start).toHaveBeenCalled()
 
-
   describe 'destroying', ->
 
     beforeEach ->
       @playScreenViewMock.remove = sinon.spy()
       @playScreen.appendToApplication()
+      @gameStub =
+        destroy: sinon.spy()
 
     it 'should tell the play screen view to remove itself', ->
       @playScreen.destroy()
 
       (expect @playScreenViewMock.remove).toHaveBeenCalled()
+
+    it 'should tell the game to destroy itself', ->
+      @playScreen.set '_game', @gameStub
+      @playScreen.destroy()
+
+      (expect @gameStub.destroy).toHaveBeenCalled()
+
+    it 'should only destroy the game if it is present', ->
+      @playScreen.destroy()
+
+      (expect @gameStub.destroy).not.toHaveBeenCalled()


### PR DESCRIPTION
When the play screen gets removed it will tell all necessary parts to destroy itself.

To stop the game loop the game loop controller has the `stopLoop` attribute which has to be set to `true`. When true it breaks out of the recursively nature of the game loop.
