### PR TITLE
Get rid of jumpstart mess in car model

### DIFF
--- a/app/assets/javascripts/slotcars/play/controllers/game_controller.js.coffee
+++ b/app/assets/javascripts/slotcars/play/controllers/game_controller.js.coffee
@@ -29,7 +29,6 @@ GameLoopController = slotcars.play.controllers.GameLoopController
   lapTimes: []
 
   init: ->
-    (@get 'car').set 'track', (@get 'track')
     @gameLoopController = GameLoopController.create()
 
     unless @track?
@@ -66,26 +65,7 @@ GameLoopController = slotcars.play.controllers.GameLoopController
   ).observes 'car.currentLap'
 
   update: ->
-    unless @car.isCrashing
-      if @isTouchMouseDown
-        @car.accelerate()
-      else
-        @car.decelerate()
-  
-      newLengthAtTrack = (@car.get 'lengthAtTrack') + (@car.get 'speed')
-      nextPosition = @track.getPointAtLength newLengthAtTrack
-
-      @car.checkForCrash nextPosition # isCrashing can be modified inside
-
-    if @car.isCrashing
-      @car.crashcelerate()
-      @car.crash()
-    else
-      @car.drive()      # automatically handles 'respawn'
-
-      # cares for correct orientation
-      @car.jumpstart()
-      @car.moveTo { x: nextPosition.x, y: nextPosition.y }
+    @car.update @isTouchMouseDown
 
     @_setCurrentTime()
 
@@ -103,10 +83,6 @@ GameLoopController = slotcars.play.controllers.GameLoopController
     @set 'raceTime', 0
     @set 'lapTimes', []
 
-    position = @track.getPointAtLength 0
-    @car.moveTo { x: position.x, y: position.y }
-
-    @car.jumpstart()
     @car.reset()
 
     @set 'currentCountdownValue', 3

--- a/app/assets/javascripts/slotcars/play/play_screen.js.coffee
+++ b/app/assets/javascripts/slotcars/play/play_screen.js.coffee
@@ -35,6 +35,7 @@ Game = slotcars.play.Game
     @track = ModelStore.findByClientId Track, @trackId
 
     @car = Car.create
+      track: @track
       acceleration: 0.1
       deceleration: 0.2
       crashDeceleration: 0.15

--- a/app/assets/javascripts/slotcars/shared/lib/movable.js.coffee
+++ b/app/assets/javascripts/slotcars/shared/lib/movable.js.coffee
@@ -8,8 +8,8 @@ Vector = helpers.math.Vector
   position: x: 0, y: 0
   rotation: 0
 
-  moveTo: (newPosition) ->
-    previousPosition = @get 'position'
+  moveTo: (newPosition, previousPosition = null) ->
+    previousPosition = @get 'position' unless previousPosition?
 
     @set 'position', newPosition
 

--- a/app/assets/javascripts/slotcars/shared/models/car.js.coffee
+++ b/app/assets/javascripts/slotcars/shared/models/car.js.coffee
@@ -23,6 +23,38 @@ Crashable = slotcars.shared.lib.Crashable
   currentLap: 0
   crossedFinishLine: false
 
+  init: ->
+    throw 'No track specified' unless @track?
+
+  update: (isTouchMouseDown) ->
+
+    nextLengthAtTrack = (@get 'lengthAtTrack') + (@get 'speed')
+    nextPosition = @track.getPointAtLength nextLengthAtTrack
+
+    unless @isCrashing
+      if isTouchMouseDown
+        @_accelerate()
+      else
+        @_decelerate()
+
+      @checkForCrash nextPosition # isCrashing can be modified inside
+
+    if @isCrashing
+      @_crashcelerate()
+      @crash()
+    else
+      @_drive() # automatically handles 'respawn'
+
+      previousPosition = @track.getPointAtLength nextLengthAtTrack - 0.1
+      @moveTo { x: nextPosition.x, y: nextPosition.y }, { x: previousPosition.x , y: previousPosition.y }
+
+  reset: ->
+    @speed = 0
+    @set 'lengthAtTrack', 0
+
+    position = @track.getPointAtLength 0
+    @moveTo { x: position.x, y: position.y }
+
   _onLengthAtTrackChanged: (->
     track = @get 'track'
     if track?
@@ -33,49 +65,18 @@ Crashable = slotcars.shared.lib.Crashable
       if isLengthAfterFinishLine isnt @get 'crossedFinishLine' then @set 'crossedFinishLine', isLengthAfterFinishLine
   ).observes 'lengthAtTrack'
 
-  init: ->
-    throw 'No track specified' unless @track?
-
-  update: (isTouchMouseDown) ->
-    unless @isCrashing
-      if isTouchMouseDown
-        @accelerate()
-      else
-        @decelerate()
-
-      newLengthAtTrack = (@get 'lengthAtTrack') + (@get 'speed')
-      nextPosition = @track.getPointAtLength newLengthAtTrack
-
-      @checkForCrash nextPosition # isCrashing can be modified inside
-
-    if @isCrashing
-      @crashcelerate()
-      @crash()
-    else
-      @drive()      # automatically handles 'respawn'
-
-      previousPosition = @track.getPointAtLength newLengthAtTrack - 0.1
-      @moveTo { x: nextPosition.x, y: nextPosition.y }, { x: previousPosition.x , y: previousPosition.y }
-
-  drive: ->
+  _drive: ->
     newLength = (@get 'lengthAtTrack') + (@get 'speed')
     @set 'lengthAtTrack', newLength
 
-  accelerate: ->
+  _accelerate: ->
     @speed += @acceleration
     if @speed > @maxSpeed then @speed = @maxSpeed
 
-  decelerate: ->
+  _decelerate: ->
     @speed -= @deceleration
     if @speed < 0 then @speed = 0
 
-  crashcelerate: ->
+  _crashcelerate: ->
     @speed -= @crashDeceleration
     if @speed < 0 then @speed = 0
-
-  reset: ->
-    @speed = 0
-    @set 'lengthAtTrack', 0
-
-    position = @track.getPointAtLength 0
-    @moveTo { x: position.x, y: position.y }

--- a/app/assets/javascripts/slotcars/shared/models/car.js.coffee
+++ b/app/assets/javascripts/slotcars/shared/models/car.js.coffee
@@ -18,7 +18,7 @@ Crashable = slotcars.shared.lib.Crashable
   crashDeceleration: 0
 
   track: null
-  lengthAtTrack: 0
+  lengthAtTrack: null
 
   currentLap: 0
   crossedFinishLine: false

--- a/spec/javascripts/unit/slotcars/play/controllers/game_controller_spec.js.coffee
+++ b/spec/javascripts/unit/slotcars/play/controllers/game_controller_spec.js.coffee
@@ -13,15 +13,20 @@ describe 'slotcars.play.controllers.GameController (unit)', ->
   Car = slotcars.shared.models.Car
 
   beforeEach ->
+    @carMock = mockEmberClass Car,
+      update: sinon.spy()
+      reset: sinon.spy()
+
     @trackMock = mockEmberClass Track,
       getPointAtLength: sinon.stub().returns { x: 0, y: 0 }
       getTotalLength: sinon.stub().returns 5
 
     @gameController = GameController.create
       track: @trackMock
-      car: Car.create()
+      car: @carMock
 
   afterEach ->
+    @carMock.restore()
     @trackMock.restore()
 
   it 'should extend Ember.Object', ->
@@ -49,9 +54,6 @@ describe 'slotcars.play.controllers.GameController (unit)', ->
     
     @GameLoopControllerMock.restore()
 
-  it 'should provide the current track for the car', ->
-    (expect @gameController.car.track).toBe @trackMock
-
   describe '#onTouchMouseDown', ->
 
     it 'should set isTouchMouseDown to true', ->
@@ -73,109 +75,115 @@ describe 'slotcars.play.controllers.GameController (unit)', ->
 
   describe '#update', ->
 
-    beforeEach ->
-      @carMock = mockEmberClass Car,
-        accelerate: sinon.spy()
-        decelerate: sinon.spy()
-        crashcelerate: sinon.spy()
-        moveTo: sinon.spy()
-        checkForCrash: sinon.spy()
-        drive: sinon.spy()
-        jumpstart: sinon.spy()
-        crash: sinon.spy()
-        reset: sinon.spy()
-        get: sinon.stub().returns 0
+    it 'should call the update function of the car', ->
+      @gameController.update()
 
-      @GameLoopControllerMock = mockEmberClass GameLoopController,
-        start: sinon.spy()
+      (expect @carMock.update).toHaveBeenCalledWith @gameController.isTouchMouseDown
 
-      @gameController.set 'car', @carMock
+  #   beforeEach ->
+  #     @carMock = mockEmberClass Car,
+  #       # accelerate: sinon.spy()
+  #       # decelerate: sinon.spy()
+  #       crashcelerate: sinon.spy()
+  #       update: sinon.spy()
+  #       # moveTo: sinon.spy()
+  #       # checkForCrash: sinon.spy()
+  #       # drive: sinon.spy()
+  #       # jumpstart: sinon.spy()
+  #       # crash: sinon.spy()
+  #       reset: sinon.spy()
+  #       get: sinon.stub().returns 0
 
-    afterEach ->
-      @GameLoopControllerMock.restore()
-      @carMock.restore()
+  #     @GameLoopControllerMock = mockEmberClass GameLoopController,
+  #       start: sinon.spy()
 
-    describe 'updating race time', ->
+  #     @gameController.set 'car', @carMock
 
-      beforeEach ->
-        @fakeTimer = sinon.useFakeTimers()
+  #   afterEach ->
+  #     @GameLoopControllerMock.restore()
+  #     @carMock.restore()
 
-      afterEach ->
-        @fakeTimer.restore()
+  #   describe 'updating race time', ->
 
-      it 'should update race time as long car is allowed to drive', ->
-        @gameController.set 'carControlsEnabled', true
+  #     beforeEach ->
+  #       @fakeTimer = sinon.useFakeTimers()
 
-        @gameController.set 'raceTime', 0
-        @gameController.set 'startTime', new Date().getTime()
+  #     afterEach ->
+  #       @fakeTimer.restore()
 
-        @fakeTimer.tick 1000
-        @gameController.update()
+  #     it 'should update race time as long car is allowed to drive', ->
+  #       @gameController.set 'carControlsEnabled', true
 
-        (expect @gameController.get 'raceTime').toEqual 1000
+  #       @gameController.set 'raceTime', 0
+  #       @gameController.set 'startTime', new Date().getTime()
 
-      it 'should not update race time when car isn´t allowed to drive', ->
-        @gameController.set 'carControlsEnabled', false
+  #       @fakeTimer.tick 1000
+  #       @gameController.update()
 
-        @gameController.set 'raceTime', 0
-        @gameController.set 'startTime', new Date().getTime()
+  #       (expect @gameController.get 'raceTime').toEqual 1000
 
-        @fakeTimer.tick 1000
-        @gameController.update()
+  #     it 'should not update race time when car isn´t allowed to drive', ->
+  #       @gameController.set 'carControlsEnabled', false
 
-        (expect @gameController.get 'raceTime').toEqual 0
+  #       @gameController.set 'raceTime', 0
+  #       @gameController.set 'startTime', new Date().getTime()
 
-    describe 'when car is on track', ->
+  #       @fakeTimer.tick 1000
+  #       @gameController.update()
 
-      beforeEach ->
-        @gameController.car.isCrashing = false
+  #       (expect @gameController.get 'raceTime').toEqual 0
 
-      it 'should accelerate car when isTouchMouseDown is true', ->
-        @gameController.isTouchMouseDown = true
-        @gameController.update()
+  #   describe 'when car is on track', ->
 
-        (expect @carMock.accelerate).toHaveBeenCalledOnce()
+  #     beforeEach ->
+  #       @gameController.car.isCrashing = false
 
-      it 'should slow down when isTouchMouseDown is false', ->
-        @gameController.isTouchMouseDown = false
-        @gameController.update()
+  #     it 'should accelerate car when isTouchMouseDown is true', ->
+  #       @gameController.isTouchMouseDown = true
+  #       @gameController.update()
 
-        (expect @carMock.decelerate).toHaveBeenCalledOnce()
-        (expect @carMock.accelerate).not.toHaveBeenCalled()
+  #       (expect @carMock.accelerate).toHaveBeenCalledOnce()
 
-      it 'should move car', ->
-        @gameController.update()
+  #     it 'should slow down when isTouchMouseDown is false', ->
+  #       @gameController.isTouchMouseDown = false
+  #       @gameController.update()
 
-        (expect @carMock.drive).toHaveBeenCalledOnce()
-        (expect @carMock.jumpstart).toHaveBeenCalledOnce()
-        (expect @carMock.moveTo).toHaveBeenCalledOnce()
+  #       (expect @carMock.decelerate).toHaveBeenCalledOnce()
+  #       (expect @carMock.accelerate).not.toHaveBeenCalled()
 
-      it 'should check for crash', ->
-        @gameController.update()
+  #     it 'should move car', ->
+  #       @gameController.update()
 
-        (expect @carMock.checkForCrash).toHaveBeenCalledOnce()
+  #       (expect @carMock.drive).toHaveBeenCalledOnce()
+  #       (expect @carMock.jumpstart).toHaveBeenCalledOnce()
+  #       (expect @carMock.moveTo).toHaveBeenCalledOnce()
 
-    describe 'when car is crashing', ->
+  #     it 'should check for crash', ->
+  #       @gameController.update()
+
+  #       (expect @carMock.checkForCrash).toHaveBeenCalledOnce()
+
+  #   describe 'when car is crashing', ->
   
-      beforeEach ->
-        @gameController.update() # simulates normal driving mode
-        @gameController.car.isCrashing = true
+  #     beforeEach ->
+  #       @gameController.update() # simulates normal driving mode
+  #       @gameController.car.isCrashing = true
 
-      it 'should slow down', ->
-        @gameController.update()
+  #     it 'should slow down', ->
+  #       @gameController.update()
 
-        (expect @carMock.crashcelerate).toHaveBeenCalledOnce()
+  #       (expect @carMock.crashcelerate).toHaveBeenCalledOnce()
 
-      it 'should not be possible to accelerate the car', ->
-        @gameController.isTouchMouseDown = true
-        @gameController.update()
+  #     it 'should not be possible to accelerate the car', ->
+  #       @gameController.isTouchMouseDown = true
+  #       @gameController.update()
 
-        (expect @carMock.accelerate).not.toHaveBeenCalled()
+  #       (expect @carMock.accelerate).not.toHaveBeenCalled()
 
-      it 'should update the car´s position', ->
-        @gameController.update()
+  #     it 'should update the car´s position', ->
+  #       @gameController.update()
 
-        (expect @carMock.crash).toHaveBeenCalledOnce()
+  #       (expect @carMock.crash).toHaveBeenCalledOnce()
 
   describe '#start', ->
 
@@ -191,6 +199,7 @@ describe 'slotcars.play.controllers.GameController (unit)', ->
 
       @gameController.track = @trackStub
       @gameController.update = sinon.spy()
+      sinon.spy @gameController, 'restartGame'
 
     afterEach ->
       @gameLoopControllerMock.restore()
@@ -201,9 +210,10 @@ describe 'slotcars.play.controllers.GameController (unit)', ->
 
       (expect @gameController.update).toHaveBeenCalled()
 
-    it 'should set car to startposition', ->
+    it 'should call the restart game function', ->
       @gameController.start()
-      (expect @gameController.car.get 'position').toEqual { x: 10, y: 10 }
+
+      (expect @gameController.restartGame).toHaveBeenCalled()
 
   describe '#finish', ->
 
@@ -237,38 +247,22 @@ describe 'slotcars.play.controllers.GameController (unit)', ->
   describe 'observing crossed finish line property of car', ->
 
     beforeEach ->
-      @carMock = mockEmberClass Car
       @gameController.finish = sinon.spy()
-
-    afterEach ->
-      @carMock.restore()
 
     it 'should observe the crossed finish line property of the car', ->
       (expect @gameController.onCarCrossedFinishLine).toObserve 'car.crossedFinishLine'
 
     it 'should finish the race when car crossed finish line', ->
-      @carMock.get = sinon.stub().withArgs('crossedFinishLine').returns true
-      @gameController.set 'car', @carMock
+      @carMock.set 'crossedFinishLine', true
 
       (expect @gameController.finish).toHaveBeenCalled()
 
     it 'should not finish the race when car didnt cross the finish line yet', ->
-      @carMock.get = sinon.stub().withArgs('crossedFinishLine').returns false
-      @gameController.set 'car', @carMock
+      @carMock.set 'crossedFinishLine', false
 
       (expect @gameController.finish).not.toHaveBeenCalled()
 
   describe '#restartGame', ->
-
-    beforeEach ->
-      @carMock = mockEmberClass Car,
-        reset: sinon.spy()
-        moveTo: sinon.spy()
-        jumpstart: sinon.spy()
-        get: sinon.spy()
-
-    afterEach ->
-      @carMock.restore()
 
     it 'should reset raceTime', ->
       @gameController.raceTime = 18
@@ -277,7 +271,6 @@ describe 'slotcars.play.controllers.GameController (unit)', ->
       (expect @gameController.get 'raceTime').toBe 0
 
     it 'should reset car', ->
-      @gameController.set 'car', @carMock
       @gameController.restartGame()
 
       (expect @carMock.reset).toHaveBeenCalled()

--- a/spec/javascripts/unit/slotcars/play/controllers/game_controller_spec.js.coffee
+++ b/spec/javascripts/unit/slotcars/play/controllers/game_controller_spec.js.coffee
@@ -80,110 +80,36 @@ describe 'slotcars.play.controllers.GameController (unit)', ->
 
       (expect @carMock.update).toHaveBeenCalledWith @gameController.isTouchMouseDown
 
-  #   beforeEach ->
-  #     @carMock = mockEmberClass Car,
-  #       # accelerate: sinon.spy()
-  #       # decelerate: sinon.spy()
-  #       crashcelerate: sinon.spy()
-  #       update: sinon.spy()
-  #       # moveTo: sinon.spy()
-  #       # checkForCrash: sinon.spy()
-  #       # drive: sinon.spy()
-  #       # jumpstart: sinon.spy()
-  #       # crash: sinon.spy()
-  #       reset: sinon.spy()
-  #       get: sinon.stub().returns 0
+    describe 'updating race time', ->
 
-  #     @GameLoopControllerMock = mockEmberClass GameLoopController,
-  #       start: sinon.spy()
+      beforeEach ->
+        @fakeTimer = sinon.useFakeTimers()
 
-  #     @gameController.set 'car', @carMock
+      afterEach ->
+        @fakeTimer.restore()
 
-  #   afterEach ->
-  #     @GameLoopControllerMock.restore()
-  #     @carMock.restore()
+      it 'should update race time as long car is allowed to drive', ->
+        @gameController.set 'carControlsEnabled', true
 
-  #   describe 'updating race time', ->
+        @gameController.set 'raceTime', 0
+        @gameController.set 'startTime', new Date().getTime()
 
-  #     beforeEach ->
-  #       @fakeTimer = sinon.useFakeTimers()
+        @fakeTimer.tick 1000
+        @gameController.update()
 
-  #     afterEach ->
-  #       @fakeTimer.restore()
+        (expect @gameController.get 'raceTime').toEqual 1000
 
-  #     it 'should update race time as long car is allowed to drive', ->
-  #       @gameController.set 'carControlsEnabled', true
+      it 'should not update race time when car isn´t allowed to drive', ->
+        @gameController.set 'carControlsEnabled', false
 
-  #       @gameController.set 'raceTime', 0
-  #       @gameController.set 'startTime', new Date().getTime()
+        @gameController.set 'raceTime', 0
+        @gameController.set 'startTime', new Date().getTime()
 
-  #       @fakeTimer.tick 1000
-  #       @gameController.update()
+        @fakeTimer.tick 1000
+        @gameController.update()
 
-  #       (expect @gameController.get 'raceTime').toEqual 1000
+        (expect @gameController.get 'raceTime').toEqual 0
 
-  #     it 'should not update race time when car isn´t allowed to drive', ->
-  #       @gameController.set 'carControlsEnabled', false
-
-  #       @gameController.set 'raceTime', 0
-  #       @gameController.set 'startTime', new Date().getTime()
-
-  #       @fakeTimer.tick 1000
-  #       @gameController.update()
-
-  #       (expect @gameController.get 'raceTime').toEqual 0
-
-  #   describe 'when car is on track', ->
-
-  #     beforeEach ->
-  #       @gameController.car.isCrashing = false
-
-  #     it 'should accelerate car when isTouchMouseDown is true', ->
-  #       @gameController.isTouchMouseDown = true
-  #       @gameController.update()
-
-  #       (expect @carMock.accelerate).toHaveBeenCalledOnce()
-
-  #     it 'should slow down when isTouchMouseDown is false', ->
-  #       @gameController.isTouchMouseDown = false
-  #       @gameController.update()
-
-  #       (expect @carMock.decelerate).toHaveBeenCalledOnce()
-  #       (expect @carMock.accelerate).not.toHaveBeenCalled()
-
-  #     it 'should move car', ->
-  #       @gameController.update()
-
-  #       (expect @carMock.drive).toHaveBeenCalledOnce()
-  #       (expect @carMock.jumpstart).toHaveBeenCalledOnce()
-  #       (expect @carMock.moveTo).toHaveBeenCalledOnce()
-
-  #     it 'should check for crash', ->
-  #       @gameController.update()
-
-  #       (expect @carMock.checkForCrash).toHaveBeenCalledOnce()
-
-  #   describe 'when car is crashing', ->
-  
-  #     beforeEach ->
-  #       @gameController.update() # simulates normal driving mode
-  #       @gameController.car.isCrashing = true
-
-  #     it 'should slow down', ->
-  #       @gameController.update()
-
-  #       (expect @carMock.crashcelerate).toHaveBeenCalledOnce()
-
-  #     it 'should not be possible to accelerate the car', ->
-  #       @gameController.isTouchMouseDown = true
-  #       @gameController.update()
-
-  #       (expect @carMock.accelerate).not.toHaveBeenCalled()
-
-  #     it 'should update the car´s position', ->
-  #       @gameController.update()
-
-  #       (expect @carMock.crash).toHaveBeenCalledOnce()
 
   describe '#start', ->
 

--- a/spec/javascripts/unit/slotcars/play/views/clock_view_spec.js.coffee
+++ b/spec/javascripts/unit/slotcars/play/views/clock_view_spec.js.coffee
@@ -22,6 +22,7 @@ describe 'slotcars.play.views.ClockView (unit)', ->
       crashDeceleration: 0.15
       maxSpeed: 20
       traction: 100
+      track: @trackModel
 
     @clockView = ClockView.create
       gameController: @gameController

--- a/spec/javascripts/unit/slotcars/shared/models/car_spec.js.coffee
+++ b/spec/javascripts/unit/slotcars/shared/models/car_spec.js.coffee
@@ -1,15 +1,13 @@
 
-#= require slotcars/shared/models/car
 #= require slotcars/shared/lib/movable
 #= require slotcars/shared/lib/crashable
 
-#= require helpers/math/vector
+#= require slotcars/shared/models/car
 #= require slotcars/shared/models/track
 
 describe 'slotcars.shared.models.Car', ->
 
   Car = slotcars.shared.models.Car
-  Vector = helpers.math.Vector
   Movable = slotcars.shared.lib.Movable
   Crashable = slotcars.shared.lib.Crashable
   Track = slotcars.shared.models.Track
@@ -19,15 +17,14 @@ describe 'slotcars.shared.models.Car', ->
       lapForLength: sinon.spy()
       isLengthAfterFinishLine: sinon.spy()
       getPointAtLength: sinon.spy()
-    
+
+    @car = Car.create
+      track: @trackMock
+
   afterEach ->
     @trackMock.restore()
 
   describe 'usage of mixins', ->
-
-    beforeEach ->
-      @car = Car.create
-        track: @trackMock
 
     it 'should use Movable', ->
       (expect Movable.detect @car).toBe true
@@ -38,15 +35,11 @@ describe 'slotcars.shared.models.Car', ->
 
   describe 'defaults on creation', ->
 
-    beforeEach ->
-      @car = Car.create
-        track: @trackMock
-
     it 'should set speed to zero', ->
       (expect @car.speed).toBe 0
 
     it 'should set lengthAtTrack', ->
-      (expect @car.lengthAtTrack).toBe 0
+      (expect @car.get 'lengthAtTrack').toBe 0
 
     it 'should set crashing to false', ->
       (expect @car.isCrashing).toBe false
@@ -55,77 +48,13 @@ describe 'slotcars.shared.models.Car', ->
       (expect @car.get 'currentLap').toBe 0
 
 
-  describe '#accelerate', ->
-
-    beforeEach ->
-      @car = Car.create
-        acceleration: 1
-        speed: 0
-        maxSpeed: 1
-        track: @trackMock
-
-    it 'should add acceleration value to speed', ->
-      @car.accelerate()
-
-      (expect @car.speed).toBe 1
-
-    it 'should not increase speed higher than maxSpeed', ->
-      @car.accelerate()
-      @car.accelerate()
-
-      (expect @car.speed).toBe 1
-
-
-  describe '#decelerate', ->
-
-    beforeEach ->
-      @car = Car.create
-        crashDeceleration: 3
-        deceleration: 4
-        speed: 5
-        track: @trackMock
-
-    it 'should decelerate with standard deceleration when car is on track', ->
-      @car.decelerate()
-
-      (expect @car.speed).toBe 1
-
-    it 'should not decrease speed below zero', ->
-      @car.decelerate()
-      @car.decelerate()
-
-      (expect @car.speed).toBe 0
-
-
-  describe '#crashcelerate', ->
-
-    beforeEach ->
-      @car = Car.create
-        crashDeceleration: 3
-        speed: 5
-        track: @trackMock
-
-    it 'should decelerate with crashDeceleration', ->
-      @car.crashcelerate()
-
-      (expect @car.speed).toBe 2
-
-    it 'should not let speed get below zero after crashing', ->
-      @car.crashDeceleration = 8
-      @car.crashcelerate()
-
-      (expect @car.speed).toBe 0
-
-
   describe '#reset', ->
 
     beforeEach ->
       @trackMock.getPointAtLength = sinon.stub().returns { x: 0, y: 0, angle: 10 }
 
-      @car = Car.create
-        speed: 10
-        lengthAtTrack: 293
-        track: @trackMock
+      @car.speed = 10
+      @car.set 'lengthAtTrack', 293
 
     it 'should reset speed', ->
       @car.reset()
@@ -135,33 +64,20 @@ describe 'slotcars.shared.models.Car', ->
     it 'should reset lengthAtTrack', ->
       @car.reset()
 
-      (expect @car.lengthAtTrack).toEqual 0
+      (expect @car.get 'lengthAtTrack').toEqual 0
 
-  describe '#drive', ->
+    it 'should move car to start', ->
+      sinon.spy @car, 'moveTo'
+      @car.reset()
 
-    beforeEach ->
-      @car = Car.create
-        speed: 1
-        track: @trackMock
-
-    it 'should update lengthAtTrack', ->
-      @car.drive()
-
-      (expect @car.lengthAtTrack).toBe 1
+      (expect @car.moveTo).toHaveBeenCalledWith { x: 0, y: 0 }
 
 
   describe 'reactions to changes of length at track', ->
 
     beforeEach ->
-      # @trackMock = mockEmberClass Track
-      # @trackMock.lapForLength = sinon.stub().returns 1
-      # @trackMock.isLengthAfterFinishLine = sinon.stub().returns false
-
-      @car = Car.create track: @trackMock
-
-    afterEach ->
-      # @trackMock.restore()
-
+      @trackMock.lapForLength = sinon.stub().returns 1
+      @trackMock.isLengthAfterFinishLine = sinon.stub().returns false
 
     describe 'current lap of car', ->
 
@@ -185,3 +101,92 @@ describe 'slotcars.shared.models.Car', ->
         @car.set 'lengthAtTrack', testLength
 
         (expect @car.get 'crossedFinishLine').toBe true
+
+
+  describe 'updating car while moving', ->
+
+    beforeEach ->
+      @trackMock.getPointAtLength = sinon.stub().returns { x: 0, y: 0, angle: 10 }
+
+      @car.acceleration = 0.2
+      @car.deceleration = 0.4
+      @car.crashDeceleration = 0.5
+      @car.speed = 5
+      @car.maxSpeed = 10
+
+    describe 'when car is on track', ->
+
+      beforeEach ->
+        @car.set 'isCrashing', false
+
+      it 'should accelerate car when update is called with true', ->
+        currentSpeed = @car.get 'speed'
+        @car.update true
+
+        (expect @car.get 'speed').toEqual currentSpeed + @car.acceleration
+
+      it 'should not accelerate above maximum speed', ->
+        currentSpeed = @car.get 'speed'
+        @car.acceleration = 10
+        @car.update true
+
+        (expect @car.get 'speed').toEqual @car.maxSpeed
+
+      it 'should decelerate car when update is called with false', ->
+        currentSpeed = @car.get 'speed'
+        @car.update false
+
+        (expect @car.get 'speed').toEqual currentSpeed - @car.deceleration
+
+      it 'should not decelerate car below zero', ->
+        currentSpeed = @car.get 'speed'
+        @car.deceleration = 10
+        @car.update false
+
+        (expect @car.get 'speed').toEqual 0
+
+      it 'should move car', ->
+        sinon.spy @car, 'set'
+        sinon.spy @car, 'moveTo'
+        @car.update false  # does not matter wether true or false
+
+        (expect @car.set).toHaveBeenCalledWith 'lengthAtTrack'
+        (expect @car.moveTo).toHaveBeenCalled()
+
+      it 'should check for crash', ->
+        @trackMock.getPointAtLength = sinon.stub().returns { x: 5, y: 5, angle: 15 }
+        sinon.spy @car, 'checkForCrash'
+        @car.update false # does not matter wether true or false
+
+        (expect @car.checkForCrash).toHaveBeenCalledWith { x: 5, y: 5, angle: 15 }
+
+    describe 'when car is crashing', ->
+
+      beforeEach ->
+        @car.update false # simulates normal driving mode
+        @car.set 'isCrashing', true
+
+      it 'should slow down', ->
+        currentSpeed = @car.get 'speed'
+        @car.update false
+
+        (expect @car.get 'speed').toEqual currentSpeed - @car.crashDeceleration
+
+      it 'should not decelerate car below zero', ->
+        currentSpeed = @car.get 'speed'
+        @car.crashDeceleration = 10
+        @car.update false
+
+        (expect @car.get 'speed').toEqual 0
+
+      it 'should not be possible to accelerate the car', ->
+        currentSpeed = @car.get 'speed'
+        @car.update true
+
+        (expect @car.get 'speed').toEqual currentSpeed - @car.crashDeceleration
+
+      it 'should update the car´s position', ->
+        sinon.spy @car, 'crash'
+        @car.update false
+
+        (expect @car.crash).toHaveBeenCalledOnce()

--- a/spec/javascripts/unit/slotcars/shared/models/car_spec.js.coffee
+++ b/spec/javascripts/unit/slotcars/shared/models/car_spec.js.coffee
@@ -14,10 +14,20 @@ describe 'slotcars.shared.models.Car', ->
   Crashable = slotcars.shared.lib.Crashable
   Track = slotcars.shared.models.Track
 
+  beforeEach ->
+    @trackMock = mockEmberClass Track,
+      lapForLength: sinon.spy()
+      isLengthAfterFinishLine: sinon.spy()
+      getPointAtLength: sinon.spy()
+    
+  afterEach ->
+    @trackMock.restore()
+
   describe 'usage of mixins', ->
 
     beforeEach ->
-      @car = Car.create()
+      @car = Car.create
+        track: @trackMock
 
     it 'should use Movable', ->
       (expect Movable.detect @car).toBe true
@@ -29,7 +39,8 @@ describe 'slotcars.shared.models.Car', ->
   describe 'defaults on creation', ->
 
     beforeEach ->
-      @car = Car.create()
+      @car = Car.create
+        track: @trackMock
 
     it 'should set speed to zero', ->
       (expect @car.speed).toBe 0
@@ -51,6 +62,7 @@ describe 'slotcars.shared.models.Car', ->
         acceleration: 1
         speed: 0
         maxSpeed: 1
+        track: @trackMock
 
     it 'should add acceleration value to speed', ->
       @car.accelerate()
@@ -71,6 +83,7 @@ describe 'slotcars.shared.models.Car', ->
         crashDeceleration: 3
         deceleration: 4
         speed: 5
+        track: @trackMock
 
     it 'should decelerate with standard deceleration when car is on track', ->
       @car.decelerate()
@@ -90,6 +103,7 @@ describe 'slotcars.shared.models.Car', ->
       @car = Car.create
         crashDeceleration: 3
         speed: 5
+        track: @trackMock
 
     it 'should decelerate with crashDeceleration', ->
       @car.crashcelerate()
@@ -106,9 +120,12 @@ describe 'slotcars.shared.models.Car', ->
   describe '#reset', ->
 
     beforeEach ->
+      @trackMock.getPointAtLength = sinon.stub().returns { x: 0, y: 0, angle: 10 }
+
       @car = Car.create
         speed: 10
         lengthAtTrack: 293
+        track: @trackMock
 
     it 'should reset speed', ->
       @car.reset()
@@ -123,7 +140,9 @@ describe 'slotcars.shared.models.Car', ->
   describe '#drive', ->
 
     beforeEach ->
-      @car = Car.create speed: 1
+      @car = Car.create
+        speed: 1
+        track: @trackMock
 
     it 'should update lengthAtTrack', ->
       @car.drive()
@@ -134,14 +153,14 @@ describe 'slotcars.shared.models.Car', ->
   describe 'reactions to changes of length at track', ->
 
     beforeEach ->
-      @trackMock = mockEmberClass Track
-      @trackMock.lapForLength = sinon.stub().returns 1
-      @trackMock.isLengthAfterFinishLine = sinon.stub().returns false
+      # @trackMock = mockEmberClass Track
+      # @trackMock.lapForLength = sinon.stub().returns 1
+      # @trackMock.isLengthAfterFinishLine = sinon.stub().returns false
 
       @car = Car.create track: @trackMock
 
     afterEach ->
-      @trackMock.restore()
+      # @trackMock.restore()
 
 
     describe 'current lap of car', ->
@@ -161,7 +180,7 @@ describe 'slotcars.shared.models.Car', ->
 
       it 'should be set to true if lengthAtTrack gets bigger than length of finish line', ->
         testLength = 3
-        @trackMock.isLengthAfterFinishLine.withArgs(testLength).returns true
+        @trackMock.isLengthAfterFinishLine = sinon.stub().withArgs(testLength).returns true
 
         @car.set 'lengthAtTrack', testLength
 

--- a/spec/javascripts/unit/slotcars/shared/models/car_spec.js.coffee
+++ b/spec/javascripts/unit/slotcars/shared/models/car_spec.js.coffee
@@ -38,9 +38,6 @@ describe 'slotcars.shared.models.Car', ->
     it 'should set speed to zero', ->
       (expect @car.speed).toBe 0
 
-    it 'should set lengthAtTrack', ->
-      (expect @car.get 'lengthAtTrack').toBe 0
-
     it 'should set crashing to false', ->
       (expect @car.isCrashing).toBe false
 


### PR DESCRIPTION
The jumpstart method of the car model is a mess that has to be removed. The car model must work with the track model and can also look up future positions to calculate the rotation. No need for leaking out the business logic of the car into other parts of the application.
