### PR TITLE
Chore/introduce closed factories

### DIFF
--- a/app/assets/javascripts/slotcars.js.coffee
+++ b/app/assets/javascripts/slotcars.js.coffee
@@ -5,6 +5,5 @@
 #= require slotcars/factories/screen_factory
 #= require slotcars/slotcars_application
 
-slotcars.SlotcarsApplication.create
-  screenFactory: slotcars.factories.ScreenFactory.create()
+slotcars.SlotcarsApplication.create()
 

--- a/app/assets/javascripts/slotcars/build/build_screen.js.coffee
+++ b/app/assets/javascripts/slotcars/build/build_screen.js.coffee
@@ -31,4 +31,4 @@ BuildScreen = (namespace 'slotcars.build').BuildScreen = Ember.Object.extend
   toString: -> '<Instance of slotcars.build.BuildScreen>'
 
 
-ScreenFactory.get().registerScreen 'BuildScreen', BuildScreen
+ScreenFactory.getInstance().registerScreen 'BuildScreen', BuildScreen

--- a/app/assets/javascripts/slotcars/build/build_screen.js.coffee
+++ b/app/assets/javascripts/slotcars/build/build_screen.js.coffee
@@ -1,10 +1,12 @@
 
 #= require slotcars/build/views/build_screen_view
 #= require slotcars/build/builder
+#= require slotcars/factories/screen_factory
 
 Builder = slotcars.build.Builder
+ScreenFactory = slotcars.factories.ScreenFactory
 
-(namespace 'slotcars.build').BuildScreen = Ember.Object.extend
+BuildScreen = (namespace 'slotcars.build').BuildScreen = Ember.Object.extend
 
   _buildScreenView: null
   _builder: null
@@ -27,3 +29,6 @@ Builder = slotcars.build.Builder
     @_buildScreenView.remove()
 
   toString: -> '<Instance of slotcars.build.BuildScreen>'
+
+
+ScreenFactory.get().registerScreen 'BuildScreen', BuildScreen

--- a/app/assets/javascripts/slotcars/factories/factory.js.coffee
+++ b/app/assets/javascripts/slotcars/factories/factory.js.coffee
@@ -3,6 +3,7 @@ Factory = (namespace 'Slotcars.factories').Factory = Ember.Object.extend
 
   _registeredTypes: []
 
+  # any type/class can be provided that provides #create to create instances
   registerType: (id, type) -> @_registeredTypes[id] = type
 
   getInstanceOf: (typeId, createParamters={}) ->
@@ -11,8 +12,12 @@ Factory = (namespace 'Slotcars.factories').Factory = Ember.Object.extend
     else
       throw "#{typeId} was not registered in factory."
 
+# reopenClass is used here to inherit the class methods (static) and attributes
+# also to subclasses. Inside the class methods 'this' points to the class itself.
 Factory.reopenClass
 
   instance: null
 
+  # all subclasses will have their own singleton @instance because
+  # 'this' points to the class that 'get' is called on.
   get: -> if @instance? then @instance else @instance = @create()

--- a/app/assets/javascripts/slotcars/factories/factory.js.coffee
+++ b/app/assets/javascripts/slotcars/factories/factory.js.coffee
@@ -10,3 +10,9 @@ Factory = (namespace 'Slotcars.factories').Factory = Ember.Object.extend
       @_registeredTypes[typeId].create createParamters
     else
       throw "#{typeId} was not registered in factory."
+
+Factory.reopenClass
+
+  instance: null
+
+  get: -> if @instance? then @instance else @instance = @create()

--- a/app/assets/javascripts/slotcars/factories/factory.js.coffee
+++ b/app/assets/javascripts/slotcars/factories/factory.js.coffee
@@ -1,0 +1,12 @@
+
+Factory = (namespace 'Slotcars.factories').Factory = Ember.Object.extend
+
+  _registeredTypes: []
+
+  registerType: (id, type) -> @_registeredTypes[id] = type
+
+  getInstanceOf: (typeId, createParamters={}) ->
+    if @_registeredTypes[typeId]?
+      @_registeredTypes[typeId].create createParamters
+    else
+      throw "#{typeId} was not registered in factory."

--- a/app/assets/javascripts/slotcars/factories/factory.js.coffee
+++ b/app/assets/javascripts/slotcars/factories/factory.js.coffee
@@ -20,4 +20,4 @@ Factory.reopenClass
 
   # all subclasses will have their own singleton @instance because
   # 'this' points to the class that 'get' is called on.
-  get: -> if @instance? then @instance else @instance = @create()
+  getInstance: -> if @instance? then @instance else @instance = @create()

--- a/app/assets/javascripts/slotcars/factories/screen_factory.js.coffee
+++ b/app/assets/javascripts/slotcars/factories/screen_factory.js.coffee
@@ -1,16 +1,6 @@
 
-#= require slotcars/build/build_screen
-#= require slotcars/play/play_screen
-#= require slotcars/tracks/tracks_screen
-#= require slotcars/home/home_screen
+#= require slotcars/factories/factory
 
-(namespace 'slotcars.factories').ScreenFactory = Ember.Object.extend
+ScreenFactory = (namespace 'slotcars.factories').ScreenFactory = Slotcars.factories.Factory.extend
 
-  getBuildScreen: -> slotcars.build.BuildScreen.create()
-
-  getPlayScreen: (trackId) ->
-    (slotcars.play.PlayScreen.create trackId: trackId)
-
-  getTracksScreen: -> slotcars.tracks.TracksScreen.create()
-
-  getHomeScreen: -> slotcars.home.HomeScreen.create()
+  registerScreen: (id, screenType) -> @registerType id, screenType

--- a/app/assets/javascripts/slotcars/home/home_screen.js.coffee
+++ b/app/assets/javascripts/slotcars/home/home_screen.js.coffee
@@ -20,4 +20,4 @@ HomeScreen = (namespace 'slotcars.home').HomeScreen = Ember.Object.extend
     @_homeScreenView.remove()
 
 
-ScreenFactory.get().registerScreen 'HomeScreen', HomeScreen
+ScreenFactory.getInstance().registerScreen 'HomeScreen', HomeScreen

--- a/app/assets/javascripts/slotcars/home/home_screen.js.coffee
+++ b/app/assets/javascripts/slotcars/home/home_screen.js.coffee
@@ -1,7 +1,10 @@
 
 #= require slotcars/home/views/home_screen_view
+#= require slotcars/factories/screen_factory
 
-(namespace 'slotcars.home').HomeScreen = Ember.Object.extend
+ScreenFactory = slotcars.factories.ScreenFactory
+
+HomeScreen = (namespace 'slotcars.home').HomeScreen = Ember.Object.extend
 
   _homeScreenView: null
 
@@ -15,3 +18,6 @@
   destroy: ->
     @_super()
     @_homeScreenView.remove()
+
+
+ScreenFactory.get().registerScreen 'HomeScreen', HomeScreen

--- a/app/assets/javascripts/slotcars/play/play_screen.js.coffee
+++ b/app/assets/javascripts/slotcars/play/play_screen.js.coffee
@@ -5,6 +5,7 @@
 #= require slotcars/shared/models/model_store
 #= require slotcars/shared/models/car
 #= require slotcars/play/game
+#= require slotcars/factories/screen_factory
 
 ModelStore = slotcars.shared.models.ModelStore
 Track = slotcars.shared.models.Track
@@ -12,8 +13,9 @@ PlayScreenView = slotcars.play.views.PlayScreenView
 PlayScreenStateManager = slotcars.play.PlayScreenStateManager
 Car = slotcars.shared.models.Car
 Game = slotcars.play.Game
+ScreenFactory = slotcars.factories.ScreenFactory
 
-(namespace 'slotcars.play').PlayScreen = Ember.Object.extend
+PlayScreen = (namespace 'slotcars.play').PlayScreen = Ember.Object.extend
 
   trackId: null
   _playScreenView: null
@@ -53,3 +55,6 @@ Game = slotcars.play.Game
 
   play: ->
     @_game.start()
+
+
+ScreenFactory.get().registerScreen 'PlayScreen', PlayScreen

--- a/app/assets/javascripts/slotcars/play/play_screen.js.coffee
+++ b/app/assets/javascripts/slotcars/play/play_screen.js.coffee
@@ -57,4 +57,4 @@ PlayScreen = (namespace 'slotcars.play').PlayScreen = Ember.Object.extend
     @_game.start()
 
 
-ScreenFactory.get().registerScreen 'PlayScreen', PlayScreen
+ScreenFactory.getInstance().registerScreen 'PlayScreen', PlayScreen

--- a/app/assets/javascripts/slotcars/route_manager.js.coffee
+++ b/app/assets/javascripts/slotcars/route_manager.js.coffee
@@ -9,17 +9,18 @@
 
   Build: Ember.State.create
     route: 'build'
-    enter: (manager) -> manager.delegate.showBuildScreen()
+    enter: (manager) -> manager.delegate.showScreen 'BuildScreen'
 
   Play: Ember.State.create
     route: 'play/:id'
-    enter: (manager) -> manager.delegate.showPlayScreen (manager.getPath 'params.id')
+    enter: (manager) -> 
+      manager.delegate.showScreen 'PlayScreen', trackId: (parseInt manager.getPath 'params.id')
 
   Tracks: Ember.State.create
     route: 'tracks'
-    enter: (manager) -> manager.delegate.showTracksScreen()
+    enter: (manager) -> manager.delegate.showScreen 'TracksScreen'
 
   Home: Ember.State.create
     route: ''
     enter: (manager) ->
-      manager.delegate.showHomeScreen()
+      manager.delegate.showScreen 'HomeScreen'

--- a/app/assets/javascripts/slotcars/slotcars_application.js.coffee
+++ b/app/assets/javascripts/slotcars/slotcars_application.js.coffee
@@ -16,24 +16,9 @@ ScreenFactory = slotcars.factories.ScreenFactory
     slotcars.routeManager = slotcars.RouteManager.create delegate: this
     helpers.routing.routeLocalLinks slotcars.routeManager
 
-  showBuildScreen: ->
+  showScreen: (screenId, createParamters) ->
     @_destroyCurrentScreen()
-    @_currentScreen = ScreenFactory.get().getInstanceOf 'BuildScreen'
-    @_currentScreen.appendToApplication()
-
-  showPlayScreen: (trackId) ->
-    @_destroyCurrentScreen()
-    @_currentScreen = ScreenFactory.get().getInstanceOf 'PlayScreen', trackId: trackId
-    @_currentScreen.appendToApplication()
-
-  showTracksScreen: ->
-    @_destroyCurrentScreen()
-    @_currentScreen = ScreenFactory.get().getInstanceOf 'TracksScreen'
-    @_currentScreen.appendToApplication()
-
-  showHomeScreen: ->
-    @_destroyCurrentScreen()
-    @_currentScreen = ScreenFactory.get().getInstanceOf 'HomeScreen'
+    @_currentScreen = ScreenFactory.getInstance().getInstanceOf screenId, createParamters
     @_currentScreen.appendToApplication()
 
   _destroyCurrentScreen: -> @_currentScreen.destroy() if @_currentScreen

--- a/app/assets/javascripts/slotcars/slotcars_application.js.coffee
+++ b/app/assets/javascripts/slotcars/slotcars_application.js.coffee
@@ -1,9 +1,15 @@
 
 #= require slotcars/route_manager
 #= require helpers/routing/route_local_links
+#= require slotcars/build/build_screen
+#= require slotcars/home/home_screen
+#= require slotcars/play/play_screen
+#= require slotcars/tracks/tracks_screen
+#= require slotcars/factories/screen_factory
+
+ScreenFactory = slotcars.factories.ScreenFactory
 
 (namespace 'slotcars').SlotcarsApplication = Ember.Application.extend
-  screenFactory: null
   _currentScreen: null
 
   ready: ->
@@ -12,22 +18,22 @@
 
   showBuildScreen: ->
     @_destroyCurrentScreen()
-    @_currentScreen = @screenFactory.getBuildScreen()
+    @_currentScreen = ScreenFactory.get().getInstanceOf 'BuildScreen'
     @_currentScreen.appendToApplication()
 
   showPlayScreen: (trackId) ->
     @_destroyCurrentScreen()
-    @_currentScreen = @screenFactory.getPlayScreen trackId
+    @_currentScreen = ScreenFactory.get().getInstanceOf 'PlayScreen', trackId: trackId
     @_currentScreen.appendToApplication()
 
   showTracksScreen: ->
     @_destroyCurrentScreen()
-    @_currentScreen = @screenFactory.getTracksScreen()
+    @_currentScreen = ScreenFactory.get().getInstanceOf 'TracksScreen'
     @_currentScreen.appendToApplication()
 
   showHomeScreen: ->
     @_destroyCurrentScreen()
-    @_currentScreen = @screenFactory.getHomeScreen()
+    @_currentScreen = ScreenFactory.get().getInstanceOf 'HomeScreen'
     @_currentScreen.appendToApplication()
 
   _destroyCurrentScreen: -> @_currentScreen.destroy() if @_currentScreen

--- a/app/assets/javascripts/slotcars/tracks/tracks_screen.js.coffee
+++ b/app/assets/javascripts/slotcars/tracks/tracks_screen.js.coffee
@@ -1,11 +1,13 @@
 
 #= require slotcars/tracks/controllers/tracks_controller
 #= require slotcars/tracks/views/tracks_screen_view
+#= require slotcars/factories/screen_factory
 
 TracksController = slotcars.tracks.controllers.TracksController
 TracksScreenView = slotcars.tracks.views.TracksScreenView
+ScreenFactory = slotcars.factories.ScreenFactory
 
-(namespace 'slotcars.tracks').TracksScreen = Ember.Object.extend
+TracksScreen = (namespace 'slotcars.tracks').TracksScreen = Ember.Object.extend
 
   appendToApplication: ->
     @_tracksScreenView = TracksScreenView.create()
@@ -18,3 +20,6 @@ TracksScreenView = slotcars.tracks.views.TracksScreenView
   destroy: ->
     @_super()
     @_tracksScreenView.remove()
+
+
+ScreenFactory.get().registerScreen 'TracksScreen', TracksScreen

--- a/app/assets/javascripts/slotcars/tracks/tracks_screen.js.coffee
+++ b/app/assets/javascripts/slotcars/tracks/tracks_screen.js.coffee
@@ -22,4 +22,4 @@ TracksScreen = (namespace 'slotcars.tracks').TracksScreen = Ember.Object.extend
     @_tracksScreenView.remove()
 
 
-ScreenFactory.get().registerScreen 'TracksScreen', TracksScreen
+ScreenFactory.getInstance().registerScreen 'TracksScreen', TracksScreen

--- a/spec/javascripts/unit/slotcars/build/build_screen_spec.js.coffee
+++ b/spec/javascripts/unit/slotcars/build/build_screen_spec.js.coffee
@@ -21,7 +21,7 @@ describe 'slotcars.build.BuildScreen', ->
     @builderControllerMock.restore()
 
   it 'should register itself at the screen factory', ->
-    buildScreen = ScreenFactory.get().getInstanceOf 'BuildScreen'
+    buildScreen = ScreenFactory.getInstance().getInstanceOf 'BuildScreen'
 
     (expect buildScreen).toBeInstanceOf BuildScreen
 

--- a/spec/javascripts/unit/slotcars/build/build_screen_spec.js.coffee
+++ b/spec/javascripts/unit/slotcars/build/build_screen_spec.js.coffee
@@ -2,12 +2,14 @@
 #= require slotcars/build/build_screen
 #= require slotcars/build/views/build_screen_view
 #= require slotcars/build/builder
+#= require slotcars/factories/screen_factory
 
 describe 'slotcars.build.BuildScreen', ->
 
   BuildScreen = slotcars.build.BuildScreen
   BuilderController = slotcars.build.Builder
   BuilderScreenView = slotcars.build.views.BuildScreenView
+  ScreenFactory = slotcars.factories.ScreenFactory
 
   beforeEach ->
     @buildScreenViewMock = mockEmberClass BuilderScreenView, append: sinon.spy()
@@ -17,6 +19,12 @@ describe 'slotcars.build.BuildScreen', ->
   afterEach ->
     @buildScreenViewMock.restore()
     @builderControllerMock.restore()
+
+  it 'should register itself at the screen factory', ->
+    buildScreen = ScreenFactory.get().getInstanceOf 'BuildScreen'
+
+    (expect buildScreen).toBeInstanceOf BuildScreen
+
 
   describe 'append to application', ->
 

--- a/spec/javascripts/unit/slotcars/factories/factory_spec.js.coffee
+++ b/spec/javascripts/unit/slotcars/factories/factory_spec.js.coffee
@@ -47,8 +47,8 @@ describe 'abstract factory', ->
   describe 'getting singleton instance of factory', ->
 
     it 'should provide a method to always retrieve the same instance', ->
-      firstInstance = Factory.get()
-      secondInstance = Factory.get()
+      firstInstance = Factory.getInstance()
+      secondInstance = Factory.getInstance()
 
       (expect firstInstance).toBeInstanceOf Factory
       (expect secondInstance).toBe firstInstance
@@ -57,7 +57,7 @@ describe 'abstract factory', ->
       FirstFactory = Factory.extend()
       SecondFactory = Factory.extend()
 
-      instanceOfFirstFactory = FirstFactory.get()
-      instanceOfSecondFactory = SecondFactory.get()
+      instanceOfFirstFactory = FirstFactory.getInstance()
+      instanceOfSecondFactory = SecondFactory.getInstance()
 
       (expect instanceOfFirstFactory).not.toBe instanceOfSecondFactory

--- a/spec/javascripts/unit/slotcars/factories/factory_spec.js.coffee
+++ b/spec/javascripts/unit/slotcars/factories/factory_spec.js.coffee
@@ -42,3 +42,22 @@ describe 'abstract factory', ->
 
       (expect secondInstance).toBeInstanceOf @SecondType
       (expect thirdInstance).toBeInstanceOf @ThirdType
+
+
+  describe 'getting singleton instance of factory', ->
+
+    it 'should provide a method to always retrieve the same instance', ->
+      firstInstance = Factory.get()
+      secondInstance = Factory.get()
+
+      (expect firstInstance).toBeInstanceOf Factory
+      (expect secondInstance).toBe firstInstance
+
+    it 'should correctly inherit static method to subclasses', ->
+      FirstFactory = Factory.extend()
+      SecondFactory = Factory.extend()
+
+      instanceOfFirstFactory = FirstFactory.get()
+      instanceOfSecondFactory = SecondFactory.get()
+
+      (expect instanceOfFirstFactory).not.toBe instanceOfSecondFactory

--- a/spec/javascripts/unit/slotcars/factories/factory_spec.js.coffee
+++ b/spec/javascripts/unit/slotcars/factories/factory_spec.js.coffee
@@ -1,0 +1,44 @@
+
+#= require slotcars/factories/factory
+
+describe 'abstract factory', ->
+
+  Factory = Slotcars.factories.Factory
+
+  describe 'registering types and getting instances', ->
+
+    beforeEach ->
+      @factory = Factory.create()
+      @ExpectedType = Ember.Object.extend()
+      @factory.registerType 'ExpectedType', @ExpectedType
+
+    it 'should throw when trying to get an instance of an unregistered type', ->
+      type = 'NotRegistered'
+
+      getUnregisteredType = => @factory.getInstanceOf type
+
+      (expect getUnregisteredType).toThrow "#{type} was not registered in factory."
+
+    it 'should return instances for registered type', ->
+      returnedInstance =  @factory.getInstanceOf 'ExpectedType'
+
+      (expect returnedInstance).toBeInstanceOf @ExpectedType
+
+    it 'should provide parameter hash when creating instance', ->
+      instanceWithParams = @factory.getInstanceOf 'ExpectedType', x: 'provided', y: 'param'
+
+      (expect instanceWithParams.get 'x').toBe 'provided'
+      (expect instanceWithParams.get 'y').toBe 'param'
+
+    it 'should be possible to register multiple types', ->
+      @SecondType = Ember.Object.extend()
+      @factory.registerType 'SecondType', @SecondType
+
+      @ThirdType = Ember.Object.extend()
+      @factory.registerType 'ThirdType', @ThirdType
+
+      secondInstance = @factory.getInstanceOf 'SecondType'
+      thirdInstance = @factory.getInstanceOf 'ThirdType'
+
+      (expect secondInstance).toBeInstanceOf @SecondType
+      (expect thirdInstance).toBeInstanceOf @ThirdType

--- a/spec/javascripts/unit/slotcars/factories/screen_factory_spec.js.coffee
+++ b/spec/javascripts/unit/slotcars/factories/screen_factory_spec.js.coffee
@@ -1,55 +1,23 @@
 
+#= require slotcars/factories/factory
 #= require slotcars/factories/screen_factory
-#= require slotcars/build/build_screen
-#= require slotcars/tracks/tracks_screen
-#= require slotcars/home/home_screen
 
 describe 'screen factory', ->
 
   ScreenFactory = slotcars.factories.ScreenFactory
-  BuildScreen = slotcars.build.BuildScreen
-  TracksScreen = slotcars.tracks.TracksScreen
-  HomeScreen = slotcars.home.HomeScreen
 
-  beforeEach ->
-    @screenFactory = ScreenFactory.create()
-
-  describe 'getting build screen', ->
-
-    it 'should return an instance of the build screen', ->
-      buildScreen = @screenFactory.getBuildScreen()
-
-      (expect buildScreen).toBeInstanceOf BuildScreen
+  it 'should be a factory', -> (expect ScreenFactory).toExtend Slotcars.factories.Factory
 
 
-  describe 'getting play screen', ->
+  describe 'registering screens', ->
 
-    beforeEach ->
-      @playScreenInstanceStub = {}
-      @playScreenCreateStub = (sinon.stub slotcars.play.PlayScreen, 'create')
-      @playScreenCreateStub.returns @playScreenInstanceStub
+    beforeEach -> @screenFactory = ScreenFactory.create()
 
-    afterEach ->
-      @playScreenCreateStub.restore()
+    it 'should provide specific method for registering screens', ->
+      registerTypeStub = sinon.stub @screenFactory, 'registerType'
+      id = 'TestScreen'
+      testScreen = {}
 
-    it 'should return an instance of the play screen and provide id', ->
-      playScreen = @screenFactory.getPlayScreen 42
+      @screenFactory.registerScreen id, testScreen
 
-      (expect @playScreenCreateStub).toHaveBeenCalledWithAnObjectLike trackId: 42
-      (expect playScreen).toBe @playScreenInstanceStub
-
-
-  describe 'getting tracks screen', ->
-
-    it 'should return an instance of the tracks screen', ->
-      tracksScreen = @screenFactory.getTracksScreen()
-
-      (expect tracksScreen).toBeInstanceOf TracksScreen
-
-
-  describe 'getting home screen', ->
-
-    it 'should return an instance of the home screen', ->
-      homeScreen = @screenFactory.getHomeScreen()
-
-      (expect homeScreen).toBeInstanceOf HomeScreen
+      (expect registerTypeStub).toHaveBeenCalledWith id, testScreen

--- a/spec/javascripts/unit/slotcars/home/home_screen_spec.js.coffee
+++ b/spec/javascripts/unit/slotcars/home/home_screen_spec.js.coffee
@@ -18,7 +18,7 @@ describe 'home screen', ->
 
 
   it 'should register itself at the screen factory', ->
-    homeScreen = ScreenFactory.get().getInstanceOf 'HomeScreen'
+    homeScreen = ScreenFactory.getInstance().getInstanceOf 'HomeScreen'
 
     (expect homeScreen).toBeInstanceOf HomeScreen
 

--- a/spec/javascripts/unit/slotcars/home/home_screen_spec.js.coffee
+++ b/spec/javascripts/unit/slotcars/home/home_screen_spec.js.coffee
@@ -1,11 +1,13 @@
 
 #= require slotcars/home/home_screen
 #= require slotcars/home/views/home_screen_view
+#= require slotcars/factories/screen_factory
 
 describe 'home screen', ->
 
   HomeScreen = slotcars.home.HomeScreen
   HomeScreenView = slotcars.home.views.HomeScreenView
+  ScreenFactory = slotcars.factories.ScreenFactory
 
   beforeEach ->
     @homeScreenViewMock = mockEmberClass HomeScreenView, append: sinon.spy()
@@ -13,6 +15,13 @@ describe 'home screen', ->
 
   afterEach ->
     @homeScreenViewMock.restore()
+
+
+  it 'should register itself at the screen factory', ->
+    homeScreen = ScreenFactory.get().getInstanceOf 'HomeScreen'
+
+    (expect homeScreen).toBeInstanceOf HomeScreen
+
 
   describe 'append to application', ->
 

--- a/spec/javascripts/unit/slotcars/play/play_screen_spec.js.coffee
+++ b/spec/javascripts/unit/slotcars/play/play_screen_spec.js.coffee
@@ -34,7 +34,7 @@ describe 'play screen', ->
 
 
   it 'should register itself at the screen factory', ->
-    playScreen = ScreenFactory.get().getInstanceOf 'PlayScreen'
+    playScreen = ScreenFactory.getInstance().getInstanceOf 'PlayScreen'
 
     (expect playScreen).toBeInstanceOf PlayScreen
 

--- a/spec/javascripts/unit/slotcars/play/play_screen_spec.js.coffee
+++ b/spec/javascripts/unit/slotcars/play/play_screen_spec.js.coffee
@@ -5,6 +5,7 @@
 #= require slotcars/shared/models/track
 #= require slotcars/play/game
 #= require slotcars/shared/models/model_store
+#= require slotcars/factories/screen_factory
 
 describe 'play screen', ->
 
@@ -15,6 +16,7 @@ describe 'play screen', ->
   Car = slotcars.shared.models.Car
   Game = slotcars.play.Game
   ModelStore = slotcars.shared.models.ModelStore
+  ScreenFactory = slotcars.factories.ScreenFactory
 
   beforeEach ->
     sinon.stub ModelStore, 'find', -> Track.createRecord()
@@ -29,6 +31,12 @@ describe 'play screen', ->
     @playScreenViewMock.restore()
     @playScreenStateManagerMock.restore()
     @GameMock.restore()
+
+
+  it 'should register itself at the screen factory', ->
+    playScreen = ScreenFactory.get().getInstanceOf 'PlayScreen'
+
+    (expect playScreen).toBeInstanceOf PlayScreen
 
 
   describe 'append to application', ->

--- a/spec/javascripts/unit/slotcars/route_manager_spec.js.coffee
+++ b/spec/javascripts/unit/slotcars/route_manager_spec.js.coffee
@@ -25,7 +25,7 @@ describe 'routing', ->
   it 'should show the play screen with the correct id on /play/:id', ->
     @routeManager.set 'location', 'play/42'
 
-    (expect @slotcarsApplicationStub.showScreen).toHaveBeenCalledWith 'PlayScreen', 42
+    (expect @slotcarsApplicationStub.showScreen).toHaveBeenCalledWith 'PlayScreen', trackId: 42
 
   it 'should show the tracks screen on /tracks', ->
     @routeManager.set 'location', 'tracks'

--- a/spec/javascripts/unit/slotcars/route_manager_spec.js.coffee
+++ b/spec/javascripts/unit/slotcars/route_manager_spec.js.coffee
@@ -5,17 +5,10 @@ describe 'routing', ->
   RouteManager = slotcars.RouteManager
 
   beforeEach ->
-    @slotcarsApplicationStub =
-      showBuildScreen: sinon.spy()
-      showPlayScreen: sinon.spy()
-      showTracksScreen: sinon.spy()
-      showHomeScreen: sinon.spy()
+    @slotcarsApplicationStub = showScreen: sinon.spy()
+    @routeManager = RouteManager.create delegate: @slotcarsApplicationStub
 
-    @routeManager = RouteManager.create
-      delegate: @slotcarsApplicationStub
-
-  afterEach ->
-    @routeManager.set 'location', 'jasmine'
+  afterEach -> @routeManager.set 'location', 'jasmine'
 
   it 'should use html5 push state', ->
     (expect @routeManager.get 'wantsHistory').toBe true
@@ -27,19 +20,19 @@ describe 'routing', ->
   it 'should show the build screen on /build', ->
     @routeManager.set 'location', 'build'
 
-    (expect @slotcarsApplicationStub.showBuildScreen).toHaveBeenCalled()
+    (expect @slotcarsApplicationStub.showScreen).toHaveBeenCalledWith 'BuildScreen'
 
   it 'should show the play screen with the correct id on /play/:id', ->
     @routeManager.set 'location', 'play/42'
 
-    (expect @slotcarsApplicationStub.showPlayScreen).toHaveBeenCalledWith '42'
+    (expect @slotcarsApplicationStub.showScreen).toHaveBeenCalledWith 'PlayScreen', 42
 
   it 'should show the tracks screen on /tracks', ->
     @routeManager.set 'location', 'tracks'
 
-    (expect @slotcarsApplicationStub.showTracksScreen).toHaveBeenCalled()
+    (expect @slotcarsApplicationStub.showScreen).toHaveBeenCalledWith 'TracksScreen'
 
   it 'should show the home screen on /', ->
     @routeManager.set 'location', ''
 
-    (expect @slotcarsApplicationStub.showHomeScreen).toHaveBeenCalled()
+    (expect @slotcarsApplicationStub.showScreen).toHaveBeenCalledWith 'HomeScreen'

--- a/spec/javascripts/unit/slotcars/slotcars_application_spec.js.coffee
+++ b/spec/javascripts/unit/slotcars/slotcars_application_spec.js.coffee
@@ -20,48 +20,33 @@ describe 'slotcars application screen management', ->
       @screenMock = appendToApplication: sinon.spy()
       @screenFactoryMock = getInstanceOf: sinon.stub().returns @screenMock
 
-      (sinon.stub ScreenFactory, 'get').returns @screenFactoryMock
+      (sinon.stub ScreenFactory, 'getInstance').returns @screenFactoryMock
 
       @slotcarsApplication = SlotcarsApplication.create()
 
     afterEach ->
       @slotcarsApplication.destroy()
-      ScreenFactory.get.restore()
+      ScreenFactory.getInstance.restore()
 
 
-    it 'should get the BuildScreen and tell it to append', ->
-      @slotcarsApplication.showBuildScreen()
+    it 'should get the correct screen from factory and tell it to append', ->
+      createParameters = {}
+      @slotcarsApplication.showScreen 'ExampleScreen', createParameters
 
-      (expect @screenFactoryMock.getInstanceOf).toHaveBeenCalledWith 'BuildScreen'
-      (expect @screenMock.appendToApplication).toHaveBeenCalled()
-
-    it 'should get the PlayScreen and tell it to append', ->
-      randomId = Math.round(Math.random() * 100) + 1
-      @slotcarsApplication.showPlayScreen randomId
-
-      (expect @screenFactoryMock.getInstanceOf).toHaveBeenCalledWith 'PlayScreen', trackId: randomId
-      (expect @screenMock.appendToApplication).toHaveBeenCalled()
-
-    it 'should get the TracksScreen and tell it to append', ->
-      @slotcarsApplication.showTracksScreen()
-
-      (expect @screenFactoryMock.getInstanceOf).toHaveBeenCalledWith 'TracksScreen'
-      (expect @screenMock.appendToApplication).toHaveBeenCalled()
-
-    it 'should get the HomeScreen and tell it to append', ->
-      @slotcarsApplication.showHomeScreen()
-
-      (expect @screenFactoryMock.getInstanceOf).toHaveBeenCalledWith 'HomeScreen'
+      (expect @screenFactoryMock.getInstanceOf).toHaveBeenCalledWith 'ExampleScreen', createParameters
       (expect @screenMock.appendToApplication).toHaveBeenCalled()
 
     it 'should call the destroy method on the old screen when the screens get switched', ->
-      @homeScreenMock = appendToApplication: sinon.spy(), destroy: sinon.spy()
-      (@screenFactoryMock.getInstanceOf.withArgs 'HomeScreen').returns @homeScreenMock
+      @firstScreenMock = 
+        appendToApplication: sinon.spy(), 
+        destroy: sinon.spy()
+      
+      (@screenFactoryMock.getInstanceOf.withArgs 'FirstScreen').returns @firstScreenMock
 
-      @slotcarsApplication.showHomeScreen()
-      @slotcarsApplication.showBuildScreen()
+      @slotcarsApplication.showScreen 'FirstScreen'
+      @slotcarsApplication.showScreen 'SecondScreen'
 
-      (expect @homeScreenMock.destroy).toHaveBeenCalled()
+      (expect @firstScreenMock.destroy).toHaveBeenCalled()
 
 
   describe 'integration with the route manager', ->

--- a/spec/javascripts/unit/slotcars/slotcars_application_spec.js.coffee
+++ b/spec/javascripts/unit/slotcars/slotcars_application_spec.js.coffee
@@ -1,9 +1,12 @@
+
 #= require slotcars/slotcars_application
 #= require slotcars/route_manager
+#= require slotcars/factories/screen_factory
 
 describe 'slotcars application screen management', ->
 
   SlotcarsApplication = slotcars.SlotcarsApplication
+  ScreenFactory = slotcars.factories.ScreenFactory
 
   beforeEach ->
     @RouteManagerCreateStub = mockEmberClass slotcars.RouteManager
@@ -14,64 +17,51 @@ describe 'slotcars application screen management', ->
   describe 'interaction with screens', ->
 
     beforeEach ->
-      @buildScreenAppendToApplicationSpy = sinon.spy()
-      @playScreenAppendToApplicationSpy = sinon.spy()
-      @tracksScreenAppendToApplicationSpy = sinon.spy()
-      @homeScreenAppendToApplicationSpy = sinon.spy()
+      @screenMock = appendToApplication: sinon.spy()
+      @screenFactoryMock = getInstanceOf: sinon.stub().returns @screenMock
 
-      @screenFactoryStub =
+      (sinon.stub ScreenFactory, 'get').returns @screenFactoryMock
 
-        getBuildScreen: sinon.stub().returns
-          appendToApplication: @buildScreenAppendToApplicationSpy
-
-        getPlayScreen: sinon.stub().withArgs('42').returns
-          appendToApplication: @playScreenAppendToApplicationSpy
-
-        getTracksScreen: sinon.stub().returns
-          appendToApplication: @tracksScreenAppendToApplicationSpy
-
-        getHomeScreen: sinon.stub().returns
-          appendToApplication: @homeScreenAppendToApplicationSpy
-
-      @slotcarsApplication = SlotcarsApplication.create
-        screenFactory: @screenFactoryStub
+      @slotcarsApplication = SlotcarsApplication.create()
 
     afterEach ->
       @slotcarsApplication.destroy()
+      ScreenFactory.get.restore()
 
 
     it 'should get the BuildScreen and tell it to append', ->
       @slotcarsApplication.showBuildScreen()
 
-      (expect @buildScreenAppendToApplicationSpy).toHaveBeenCalled()
+      (expect @screenFactoryMock.getInstanceOf).toHaveBeenCalledWith 'BuildScreen'
+      (expect @screenMock.appendToApplication).toHaveBeenCalled()
 
     it 'should get the PlayScreen and tell it to append', ->
-      @slotcarsApplication.showPlayScreen 42
+      randomId = Math.round(Math.random() * 100) + 1
+      @slotcarsApplication.showPlayScreen randomId
 
-      (expect @playScreenAppendToApplicationSpy).toHaveBeenCalled()
+      (expect @screenFactoryMock.getInstanceOf).toHaveBeenCalledWith 'PlayScreen', trackId: randomId
+      (expect @screenMock.appendToApplication).toHaveBeenCalled()
 
     it 'should get the TracksScreen and tell it to append', ->
       @slotcarsApplication.showTracksScreen()
 
-      (expect @tracksScreenAppendToApplicationSpy).toHaveBeenCalled()
+      (expect @screenFactoryMock.getInstanceOf).toHaveBeenCalledWith 'TracksScreen'
+      (expect @screenMock.appendToApplication).toHaveBeenCalled()
 
     it 'should get the HomeScreen and tell it to append', ->
       @slotcarsApplication.showHomeScreen()
 
-      (expect @homeScreenAppendToApplicationSpy).toHaveBeenCalled()
+      (expect @screenFactoryMock.getInstanceOf).toHaveBeenCalledWith 'HomeScreen'
+      (expect @screenMock.appendToApplication).toHaveBeenCalled()
 
     it 'should call the destroy method on the old screen when the screens get switched', ->
-      homeScreenAppendToApplicationSpy = sinon.spy()
-      homeScreenDestroySpy = sinon.spy()
-
-      @screenFactoryStub.getHomeScreen = sinon.stub().returns
-        appendToApplication: homeScreenAppendToApplicationSpy
-        destroy: homeScreenDestroySpy
+      @homeScreenMock = appendToApplication: sinon.spy(), destroy: sinon.spy()
+      (@screenFactoryMock.getInstanceOf.withArgs 'HomeScreen').returns @homeScreenMock
 
       @slotcarsApplication.showHomeScreen()
       @slotcarsApplication.showBuildScreen()
 
-      (expect homeScreenDestroySpy).toHaveBeenCalled()
+      (expect @homeScreenMock.destroy).toHaveBeenCalled()
 
 
   describe 'integration with the route manager', ->

--- a/spec/javascripts/unit/slotcars/tracks/tracks_screen_spec.js.coffee
+++ b/spec/javascripts/unit/slotcars/tracks/tracks_screen_spec.js.coffee
@@ -24,7 +24,7 @@ describe 'tracks screen', ->
 
 
   it 'should register itself at the screen factory', ->
-    tracksScreen = ScreenFactory.get().getInstanceOf 'TracksScreen'
+    tracksScreen = ScreenFactory.getInstance().getInstanceOf 'TracksScreen'
 
     (expect tracksScreen).toBeInstanceOf TracksScreen
 

--- a/spec/javascripts/unit/slotcars/tracks/tracks_screen_spec.js.coffee
+++ b/spec/javascripts/unit/slotcars/tracks/tracks_screen_spec.js.coffee
@@ -2,12 +2,14 @@
 #= require slotcars/tracks/tracks_screen
 #= require slotcars/tracks/controllers/tracks_controller
 #= require slotcars/tracks/views/tracks_screen_view
+#= require slotcars/factories/screen_factory
 
 describe 'tracks screen', ->
 
   TracksScreen = slotcars.tracks.TracksScreen
   TracksController = slotcars.tracks.controllers.TracksController
   TracksScreenView = slotcars.tracks.views.TracksScreenView
+  ScreenFactory = slotcars.factories.ScreenFactory
 
   beforeEach ->
     @TracksControllerMock = mockEmberClass TracksController
@@ -20,8 +22,12 @@ describe 'tracks screen', ->
     @TracksControllerMock.restore()
     @TracksScreenViewMock.restore()
 
-  it 'should extend Ember.Object', ->
-    (expect TracksScreen).toExtend Ember.Object
+
+  it 'should register itself at the screen factory', ->
+    tracksScreen = ScreenFactory.get().getInstanceOf 'TracksScreen'
+
+    (expect tracksScreen).toBeInstanceOf TracksScreen
+
 
   describe 'appending tracks screen to application', ->
 


### PR DESCRIPTION
Adds closed factory (see [Factories Wiki Page](https://github.com/stravid/slotcars/wiki/Factories) and changes screen factory to be part of the game! Lets all screens register themselves at the factory and thus removes a lot of dependencies from the screen factory. Adding a new screen will just require changes in the new screen and the slotcars application code.

The `ScreenFactory` extends `Factory` and can be accessed in the code with the static `ScreenFactory.get`method which returns the singleton instance.
