### PR TITLE
Pull Request: chore/generalize screen architecture

### DIFF
--- a/app/assets/javascripts/slotcars/build/build_screen.js.coffee
+++ b/app/assets/javascripts/slotcars/build/build_screen.js.coffee
@@ -1,29 +1,30 @@
 
 #= require slotcars/build/views/build_screen_view
 #= require slotcars/build/builder
+#= require slotcars/shared/lib/appendable
 
 Builder = slotcars.build.Builder
+Appendable = slotcars.shared.lib.Appendable
 
-(namespace 'slotcars.build').BuildScreen = Ember.Object.extend
+(namespace 'slotcars.build').BuildScreen = Ember.Object.extend Appendable,
 
-  _buildScreenView: null
   _builder: null
 
   appendToApplication: ->
-    @appendScreen()
-    @setupBuilder()
+    @_appendScreen()
+    @_setupBuilder()
 
-  appendScreen: ->
-    @_buildScreenView = slotcars.build.views.BuildScreenView.create()
-    @_buildScreenView.append()
+  _appendScreen: ->
+    @view = slotcars.build.views.BuildScreenView.create()
+    @appendView()
 
-  setupBuilder: ->
+  _setupBuilder: ->
     @_builder = Builder.create
-      buildScreenView: @_buildScreenView
+      buildScreenView: @view
 
   destroy: ->
     @_super()
     @_builder.destroy()
-    @_buildScreenView.remove()
+    @removeView()
 
   toString: -> '<Instance of slotcars.build.BuildScreen>'

--- a/app/assets/javascripts/slotcars/build/build_screen.js.coffee
+++ b/app/assets/javascripts/slotcars/build/build_screen.js.coffee
@@ -11,15 +11,9 @@ Appendable = slotcars.shared.lib.Appendable
 
   _builder: null
 
-  appendToApplication: ->
-    @_appendScreen()
-    @_setupBuilder()
-
-  _appendScreen: ->
+  init: ->
     @view = BuildScreenView.create()
-    @appendView()
 
-  _setupBuilder: ->
     @_builder = Builder.create
       buildScreenView: @view
 

--- a/app/assets/javascripts/slotcars/build/build_screen.js.coffee
+++ b/app/assets/javascripts/slotcars/build/build_screen.js.coffee
@@ -4,6 +4,7 @@
 #= require slotcars/shared/lib/appendable
 
 Builder = slotcars.build.Builder
+BuildScreenView = slotcars.build.views.BuildScreenView
 Appendable = slotcars.shared.lib.Appendable
 
 (namespace 'slotcars.build').BuildScreen = Ember.Object.extend Appendable,
@@ -15,7 +16,7 @@ Appendable = slotcars.shared.lib.Appendable
     @_setupBuilder()
 
   _appendScreen: ->
-    @view = slotcars.build.views.BuildScreenView.create()
+    @view = BuildScreenView.create()
     @appendView()
 
   _setupBuilder: ->
@@ -25,6 +26,5 @@ Appendable = slotcars.shared.lib.Appendable
   destroy: ->
     @_super()
     @_builder.destroy()
-    @removeView()
 
   toString: -> '<Instance of slotcars.build.BuildScreen>'

--- a/app/assets/javascripts/slotcars/build/builder.js.coffee
+++ b/app/assets/javascripts/slotcars/build/builder.js.coffee
@@ -26,5 +26,6 @@ DrawView = slotcars.build.views.DrawView
 
   destroy: ->
     @_super()
+    @buildScreenView.set 'contentView', null
     @drawController.destroy()
-    @_drawView.remove()
+    @_drawView.destroy()

--- a/app/assets/javascripts/slotcars/home/home_screen.js.coffee
+++ b/app/assets/javascripts/slotcars/home/home_screen.js.coffee
@@ -1,17 +1,19 @@
 
 #= require slotcars/home/views/home_screen_view
+#= require slotcars/shared/lib/appendable
 
-(namespace 'slotcars.home').HomeScreen = Ember.Object.extend
+Appendable = slotcars.shared.lib.Appendable
 
-  _homeScreenView: null
+(namespace 'slotcars.home').HomeScreen = Ember.Object.extend Appendable,
 
   appendToApplication: ->
     @_appendScreen()
 
   _appendScreen: ->
-    @_homeScreenView = slotcars.home.views.HomeScreenView.create()
-    @_homeScreenView.append()
+    @view = slotcars.home.views.HomeScreenView.create()
+    @appendView()
 
   destroy: ->
     @_super()
-    @_homeScreenView.remove()
+    @removeView()
+    

--- a/app/assets/javascripts/slotcars/home/home_screen.js.coffee
+++ b/app/assets/javascripts/slotcars/home/home_screen.js.coffee
@@ -2,6 +2,7 @@
 #= require slotcars/home/views/home_screen_view
 #= require slotcars/shared/lib/appendable
 
+HomeScreenView = slotcars.home.views.HomeScreenView
 Appendable = slotcars.shared.lib.Appendable
 
 (namespace 'slotcars.home').HomeScreen = Ember.Object.extend Appendable,
@@ -10,10 +11,5 @@ Appendable = slotcars.shared.lib.Appendable
     @_appendScreen()
 
   _appendScreen: ->
-    @view = slotcars.home.views.HomeScreenView.create()
+    @view = HomeScreenView.create()
     @appendView()
-
-  destroy: ->
-    @_super()
-    @removeView()
-    

--- a/app/assets/javascripts/slotcars/home/home_screen.js.coffee
+++ b/app/assets/javascripts/slotcars/home/home_screen.js.coffee
@@ -7,9 +7,5 @@ Appendable = slotcars.shared.lib.Appendable
 
 (namespace 'slotcars.home').HomeScreen = Ember.Object.extend Appendable,
 
-  appendToApplication: ->
-    @_appendScreen()
-
-  _appendScreen: ->
+  init: ->
     @view = HomeScreenView.create()
-    @appendView()

--- a/app/assets/javascripts/slotcars/play/play_screen.js.coffee
+++ b/app/assets/javascripts/slotcars/play/play_screen.js.coffee
@@ -21,15 +21,11 @@ Appendable = slotcars.shared.lib.Appendable
   _playScreenStateManager: null
   _game: null
 
-  appendToApplication: ->
-    @_appendScreen()
+  init: ->
+    @view = PlayScreenView.create()
 
     @_playScreenStateManager = PlayScreenStateManager.create delegate: this
     @_playScreenStateManager.send 'load'
-
-  _appendScreen: ->
-    @view = PlayScreenView.create()
-    @appendView()
 
   load: ->
     @track = ModelStore.find Track, @trackId

--- a/app/assets/javascripts/slotcars/play/play_screen.js.coffee
+++ b/app/assets/javascripts/slotcars/play/play_screen.js.coffee
@@ -5,6 +5,7 @@
 #= require slotcars/shared/models/model_store
 #= require slotcars/shared/models/car
 #= require slotcars/play/game
+#= require slotcars/shared/lib/appendable
 
 ModelStore = slotcars.shared.models.ModelStore
 Track = slotcars.shared.models.Track
@@ -12,24 +13,24 @@ PlayScreenView = slotcars.play.views.PlayScreenView
 PlayScreenStateManager = slotcars.play.PlayScreenStateManager
 Car = slotcars.shared.models.Car
 Game = slotcars.play.Game
+Appendable = slotcars.shared.lib.Appendable
 
-(namespace 'slotcars.play').PlayScreen = Ember.Object.extend
+(namespace 'slotcars.play').PlayScreen = Ember.Object.extend Appendable,
 
   trackId: null
-  _playScreenView: null
   _playScreenStateManager: null
   _game: null
 
   appendToApplication: ->
     @_playScreenStateManager = PlayScreenStateManager.create delegate: this
-    @_playScreenView = PlayScreenView.create()
-    @_playScreenView.append()
+    @view = PlayScreenView.create()
+    @appendView()
 
     @_playScreenStateManager.send 'load'
 
   destroy: ->
     @_super()
-    @_playScreenView.remove()
+    @removeView()
 
   load: ->
     @track = ModelStore.find Track, @trackId
@@ -45,7 +46,7 @@ Game = slotcars.play.Game
 
   initialize: ->
     @_game = Game.create
-      playScreenView: @_playScreenView
+      playScreenView: @view
       track: @track
       car: @car
 

--- a/app/assets/javascripts/slotcars/play/play_screen.js.coffee
+++ b/app/assets/javascripts/slotcars/play/play_screen.js.coffee
@@ -22,15 +22,14 @@ Appendable = slotcars.shared.lib.Appendable
   _game: null
 
   appendToApplication: ->
-    @_playScreenStateManager = PlayScreenStateManager.create delegate: this
-    @view = PlayScreenView.create()
-    @appendView()
+    @_appendScreen()
 
+    @_playScreenStateManager = PlayScreenStateManager.create delegate: this
     @_playScreenStateManager.send 'load'
 
-  destroy: ->
-    @_super()
-    @removeView()
+  _appendScreen: ->
+    @view = PlayScreenView.create()
+    @appendView()
 
   load: ->
     @track = ModelStore.find Track, @trackId

--- a/app/assets/javascripts/slotcars/shared/lib/appendable.js.coffee
+++ b/app/assets/javascripts/slotcars/shared/lib/appendable.js.coffee
@@ -1,0 +1,4 @@
+
+(namespace 'Slotcars.shared.lib').Appendable = Ember.Mixin.create
+  
+  view: Ember.required()

--- a/app/assets/javascripts/slotcars/shared/lib/appendable.js.coffee
+++ b/app/assets/javascripts/slotcars/shared/lib/appendable.js.coffee
@@ -1,4 +1,10 @@
 
-(namespace 'Slotcars.shared.lib').Appendable = Ember.Mixin.create
+(namespace 'slotcars.shared.lib').Appendable = Ember.Mixin.create
   
   view: Ember.required()
+
+  appendView: ->
+    @view.append()
+
+  removeView: ->
+    @view.remove()

--- a/app/assets/javascripts/slotcars/shared/lib/appendable.js.coffee
+++ b/app/assets/javascripts/slotcars/shared/lib/appendable.js.coffee
@@ -3,12 +3,10 @@
   
   view: Ember.required()
 
-  appendView: ->
+  append: ->
     @view.append()
-
-  removeView: ->
-    @view.remove()
 
   destroy: ->
     @_super()
-    @removeView()
+    @view.remove()
+    @view.destroy()

--- a/app/assets/javascripts/slotcars/shared/lib/appendable.js.coffee
+++ b/app/assets/javascripts/slotcars/shared/lib/appendable.js.coffee
@@ -8,3 +8,7 @@
 
   removeView: ->
     @view.remove()
+
+  destroy: ->
+    @_super()
+    @removeView()

--- a/app/assets/javascripts/slotcars/slotcars_application.js.coffee
+++ b/app/assets/javascripts/slotcars/slotcars_application.js.coffee
@@ -13,21 +13,21 @@
   showBuildScreen: ->
     @_destroyCurrentScreen()
     @_currentScreen = @screenFactory.getBuildScreen()
-    @_currentScreen.appendToApplication()
+    @_currentScreen.append()
 
   showPlayScreen: (trackId) ->
     @_destroyCurrentScreen()
     @_currentScreen = @screenFactory.getPlayScreen trackId
-    @_currentScreen.appendToApplication()
+    @_currentScreen.append()
 
   showTracksScreen: ->
     @_destroyCurrentScreen()
     @_currentScreen = @screenFactory.getTracksScreen()
-    @_currentScreen.appendToApplication()
+    @_currentScreen.append()
 
   showHomeScreen: ->
     @_destroyCurrentScreen()
     @_currentScreen = @screenFactory.getHomeScreen()
-    @_currentScreen.appendToApplication()
+    @_currentScreen.append()
 
   _destroyCurrentScreen: -> @_currentScreen.destroy() if @_currentScreen

--- a/app/assets/javascripts/slotcars/tracks/tracks_screen.js.coffee
+++ b/app/assets/javascripts/slotcars/tracks/tracks_screen.js.coffee
@@ -1,20 +1,21 @@
 
 #= require slotcars/tracks/controllers/tracks_controller
 #= require slotcars/tracks/views/tracks_screen_view
+#= require slotcars/shared/lib/appendable
 
 TracksController = slotcars.tracks.controllers.TracksController
 TracksScreenView = slotcars.tracks.views.TracksScreenView
+Appendable = slotcars.shared.lib.Appendable
 
-(namespace 'slotcars.tracks').TracksScreen = Ember.Object.extend
+(namespace 'slotcars.tracks').TracksScreen = Ember.Object.extend Appendable,
 
   appendToApplication: ->
-    @_tracksScreenView = TracksScreenView.create()
-
-    @_tracksScreenView.append()
+    @view = TracksScreenView.create()
+    @appendView()
 
     TracksController.create
-      tracksScreenView: @_tracksScreenView
+      tracksScreenView: @view
 
   destroy: ->
     @_super()
-    @_tracksScreenView.remove()
+    @removeView()

--- a/app/assets/javascripts/slotcars/tracks/tracks_screen.js.coffee
+++ b/app/assets/javascripts/slotcars/tracks/tracks_screen.js.coffee
@@ -9,12 +9,8 @@ Appendable = slotcars.shared.lib.Appendable
 
 (namespace 'slotcars.tracks').TracksScreen = Ember.Object.extend Appendable,
 
-  appendToApplication: ->
-    @_appendScreen()
+  init: ->
+    @view = TracksScreenView.create()
 
     TracksController.create
       tracksScreenView: @view
-
-  _appendScreen: ->
-    @view = TracksScreenView.create()
-    @appendView()

--- a/app/assets/javascripts/slotcars/tracks/tracks_screen.js.coffee
+++ b/app/assets/javascripts/slotcars/tracks/tracks_screen.js.coffee
@@ -10,12 +10,11 @@ Appendable = slotcars.shared.lib.Appendable
 (namespace 'slotcars.tracks').TracksScreen = Ember.Object.extend Appendable,
 
   appendToApplication: ->
-    @view = TracksScreenView.create()
-    @appendView()
+    @_appendScreen()
 
     TracksController.create
       tracksScreenView: @view
 
-  destroy: ->
-    @_super()
-    @removeView()
+  _appendScreen: ->
+    @view = TracksScreenView.create()
+    @appendView()

--- a/spec/javascripts/unit/slotcars/build/build_screen_spec.js.coffee
+++ b/spec/javascripts/unit/slotcars/build/build_screen_spec.js.coffee
@@ -20,10 +20,13 @@ describe 'slotcars.build.BuildScreen', ->
 
   describe 'append to application', ->
 
-    it 'should append the build screen view to the DOM body', ->
+    beforeEach ->
+      @buildScreen.appendView = sinon.spy()
+
+    it 'should call appendView method on itself', ->
       @buildScreen.appendToApplication()
 
-      (expect @buildScreenViewMock.append).toHaveBeenCalled()
+      (expect @buildScreen.appendView).toHaveBeenCalled()
 
     it 'should create builder and provide build screen view', ->
       @buildScreen.appendToApplication()
@@ -37,11 +40,6 @@ describe 'slotcars.build.BuildScreen', ->
       @builderControllerMock.destroy = sinon.spy()
       @buildScreenViewMock.remove = sinon.spy()
       @buildScreen.appendToApplication()
-
-    it 'should tell the build screen view to remove itself', ->
-      @buildScreen.destroy()
-
-      (expect @buildScreenViewMock.remove).toHaveBeenCalled()
 
     it 'should tell the builder to destroy itself', ->
       @buildScreen.destroy()

--- a/spec/javascripts/unit/slotcars/build/build_screen_spec.js.coffee
+++ b/spec/javascripts/unit/slotcars/build/build_screen_spec.js.coffee
@@ -7,10 +7,10 @@ describe 'slotcars.build.BuildScreen', ->
 
   BuildScreen = slotcars.build.BuildScreen
   BuilderController = slotcars.build.Builder
-  BuilderScreenView = slotcars.build.views.BuildScreenView
+  BuildScreenView = slotcars.build.views.BuildScreenView
 
   beforeEach ->
-    @buildScreenViewMock = mockEmberClass BuilderScreenView,
+    @buildScreenViewMock = mockEmberClass BuildScreenView,
       append: sinon.spy()
       remove: sinon.spy()
 
@@ -21,27 +21,16 @@ describe 'slotcars.build.BuildScreen', ->
     @buildScreenViewMock.restore()
     @builderControllerMock.restore()
 
-  describe 'append to application', ->
+  it 'should create build screen view', ->
+    (expect @buildScreenViewMock.create).toHaveBeenCalled()
 
-    beforeEach ->
-      @buildScreen.appendView = sinon.spy()
-
-    it 'should call appendView method on itself', ->
-      @buildScreen.appendToApplication()
-
-      (expect @buildScreen.appendView).toHaveBeenCalled()
-
-    it 'should create builder and provide build screen view', ->
-      @buildScreen.appendToApplication()
-
-      (expect @builderControllerMock.create).toHaveBeenCalledWithAnObjectLike buildScreenView: @buildScreenViewMock
-
+  it 'should create builder and provide build screen view', ->
+    (expect @builderControllerMock.create).toHaveBeenCalledWithAnObjectLike buildScreenView: @buildScreenViewMock
 
   describe 'destroy', ->
 
     beforeEach ->
       @builderControllerMock.destroy = sinon.spy()
-      @buildScreen.appendToApplication()
 
     it 'should tell the builder to destroy itself', ->
       @buildScreen.destroy()

--- a/spec/javascripts/unit/slotcars/build/build_screen_spec.js.coffee
+++ b/spec/javascripts/unit/slotcars/build/build_screen_spec.js.coffee
@@ -38,7 +38,6 @@ describe 'slotcars.build.BuildScreen', ->
 
     beforeEach ->
       @builderControllerMock.destroy = sinon.spy()
-      @buildScreenViewMock.remove = sinon.spy()
       @buildScreen.appendToApplication()
 
     it 'should tell the builder to destroy itself', ->

--- a/spec/javascripts/unit/slotcars/build/build_screen_spec.js.coffee
+++ b/spec/javascripts/unit/slotcars/build/build_screen_spec.js.coffee
@@ -10,7 +10,10 @@ describe 'slotcars.build.BuildScreen', ->
   BuilderScreenView = slotcars.build.views.BuildScreenView
 
   beforeEach ->
-    @buildScreenViewMock = mockEmberClass BuilderScreenView, append: sinon.spy()
+    @buildScreenViewMock = mockEmberClass BuilderScreenView,
+      append: sinon.spy()
+      remove: sinon.spy()
+
     @builderControllerMock = mockEmberClass BuilderController
     @buildScreen = BuildScreen.create()
 

--- a/spec/javascripts/unit/slotcars/build/builder_spec.js.coffee
+++ b/spec/javascripts/unit/slotcars/build/builder_spec.js.coffee
@@ -62,16 +62,20 @@ describe 'builder', ->
 
     beforeEach ->
       @DrawControllerMock.destroy = sinon.spy()
-      @DrawViewMock.remove = sinon.spy()
+      @DrawViewMock.destroy = sinon.spy()
       @builder = Builder.create buildScreenView: @buildScreenViewStub
 
+    it 'should unset content view property of build screen view', ->
+      @builder.destroy()
+
+      (expect @buildScreenViewStub.set).toHaveBeenCalledWith 'contentView', null
 
     it 'should tell the draw controller to destroy itself', ->
       @builder.destroy()
 
       (expect @DrawControllerMock.destroy).toHaveBeenCalled()
 
-    it 'should tell the draw view to remove itself', ->
+    it 'should tell the draw view to destroy itself', ->
       @builder.destroy()
 
-      (expect @DrawViewMock.remove).toHaveBeenCalled()
+      (expect @DrawViewMock.destroy).toHaveBeenCalled()

--- a/spec/javascripts/unit/slotcars/home/home_screen_spec.js.coffee
+++ b/spec/javascripts/unit/slotcars/home/home_screen_spec.js.coffee
@@ -16,18 +16,10 @@ describe 'home screen', ->
 
   describe 'append to application', ->
 
-    it 'should append the home screen view to the DOM body', ->
-      @homeScreen.appendToApplication()
-
-      (expect @homeScreenViewMock.append).toHaveBeenCalled()
-
-  describe 'destroy', ->
-
     beforeEach ->
-      @homeScreenViewMock.remove = sinon.spy()
+      @homeScreen.appendView = sinon.spy()
+
+    it 'should call appendView method on itself', ->
       @homeScreen.appendToApplication()
 
-    it 'should tell the home screen view to remove itself', ->
-      @homeScreen.destroy()
-
-      (expect @homeScreenViewMock.remove).toHaveBeenCalled()
+      (expect @homeScreen.appendView).toHaveBeenCalled()

--- a/spec/javascripts/unit/slotcars/home/home_screen_spec.js.coffee
+++ b/spec/javascripts/unit/slotcars/home/home_screen_spec.js.coffee
@@ -8,18 +8,11 @@ describe 'home screen', ->
   HomeScreenView = slotcars.home.views.HomeScreenView
 
   beforeEach ->
-    @homeScreenViewMock = mockEmberClass HomeScreenView, append: sinon.spy()
+    @homeScreenViewMock = mockEmberClass HomeScreenView
     @homeScreen = HomeScreen.create()
 
   afterEach ->
     @homeScreenViewMock.restore()
 
-  describe 'append to application', ->
-
-    beforeEach ->
-      @homeScreen.appendView = sinon.spy()
-
-    it 'should call appendView method on itself', ->
-      @homeScreen.appendToApplication()
-
-      (expect @homeScreen.appendView).toHaveBeenCalled()
+  it 'should create home screen view', ->
+    (expect @homeScreenViewMock.create).toHaveBeenCalled()

--- a/spec/javascripts/unit/slotcars/play/play_screen_spec.js.coffee
+++ b/spec/javascripts/unit/slotcars/play/play_screen_spec.js.coffee
@@ -19,7 +19,9 @@ describe 'play screen', ->
   beforeEach ->
     sinon.stub ModelStore, 'find', -> Track.createRecord()
 
-    @playScreenViewMock = mockEmberClass PlayScreenView, append: sinon.spy()
+    @playScreenViewMock = mockEmberClass PlayScreenView,
+      append: sinon.spy()
+      remove: sinon.spy()
     @playScreenStateManagerMock = mockEmberClass PlayScreenStateManager, send: sinon.spy()
     @GameMock = mockEmberClass Game,
       start: sinon.spy()

--- a/spec/javascripts/unit/slotcars/play/play_screen_spec.js.coffee
+++ b/spec/javascripts/unit/slotcars/play/play_screen_spec.js.coffee
@@ -35,17 +35,15 @@ describe 'play screen', ->
 
     beforeEach ->
       @playScreen.load = sinon.spy()
+      @playScreen.appendView = sinon.spy()
+      
+      @playScreen.appendToApplication()
 
     it 'should create the play screen state manager', ->
-      @playScreen.appendToApplication()
-
       (expect @playScreenStateManagerMock.create).toHaveBeenCalled()
 
-    it 'should append the play screen view to the DOM', ->
-      @playScreen.appendToApplication()
-
-      (expect @playScreenViewMock.append).toHaveBeenCalled()
-
+    it 'should call appendView method on itself', ->
+      (expect @playScreen.appendView).toHaveBeenCalled()
 
   describe 'loading', ->
 
@@ -92,15 +90,3 @@ describe 'play screen', ->
 
     it 'should start the game', ->
       (expect @GameMock.start).toHaveBeenCalled()
-
-
-  describe 'destroying', ->
-
-    beforeEach ->
-      @playScreenViewMock.remove = sinon.spy()
-      @playScreen.appendToApplication()
-
-    it 'should tell the play screen view to remove itself', ->
-      @playScreen.destroy()
-
-      (expect @playScreenViewMock.remove).toHaveBeenCalled()

--- a/spec/javascripts/unit/slotcars/play/play_screen_spec.js.coffee
+++ b/spec/javascripts/unit/slotcars/play/play_screen_spec.js.coffee
@@ -30,25 +30,13 @@ describe 'play screen', ->
     @playScreenStateManagerMock.restore()
     @GameMock.restore()
 
+  it 'should create play screen view', ->
+    (expect @playScreenViewMock.create).toHaveBeenCalled()
 
-  describe 'append to application', ->
-
-    beforeEach ->
-      @playScreen.load = sinon.spy()
-      @playScreen.appendView = sinon.spy()
-      
-      @playScreen.appendToApplication()
-
-    it 'should create the play screen state manager', ->
-      (expect @playScreenStateManagerMock.create).toHaveBeenCalled()
-
-    it 'should call appendView method on itself', ->
-      (expect @playScreen.appendView).toHaveBeenCalled()
+  it 'should create the play screen state manager', ->
+    (expect @playScreenStateManagerMock.create).toHaveBeenCalled()
 
   describe 'loading', ->
-
-    beforeEach ->
-      @playScreen.appendToApplication()
 
     it 'should load a track', ->
       @playScreen.load()
@@ -69,7 +57,6 @@ describe 'play screen', ->
   describe 'initializing', ->
 
     beforeEach ->
-      @playScreen.appendToApplication()
       @playScreen.load()
       @playScreen.initialize()
 
@@ -83,7 +70,6 @@ describe 'play screen', ->
   describe 'playing', ->
 
     beforeEach ->
-      @playScreen.appendToApplication()
       @playScreen.load()
       @playScreen.initialize()
       @playScreen.play()

--- a/spec/javascripts/unit/slotcars/shared/lib/appendable_spec.js.coffee
+++ b/spec/javascripts/unit/slotcars/shared/lib/appendable_spec.js.coffee
@@ -9,34 +9,35 @@ describe 'Appendable', ->
     @viewMock =
       append: sinon.spy()
       remove: sinon.spy()
+      destroy: sinon.spy()
 
-    @appendable = Ember.Object.extend(Appendable).create()
-    @appendable.view = @viewMock
+    @appendable = Ember.Object.extend(Appendable).create
+      view: @viewMock
 
-  it 'should require a view', ->
-    (expect => Appendable.apply {}).toThrow()
+  it 'should always require a view', ->
+    # applies the Appendable mixin on an object - assumes an error when 'view' property is not set
+    # Ember.required() just works/fires when the mixin is applied after creation
+    (expect => Appendable.apply Ember.Object.create()).toThrow()
 
-  describe 'append to application', ->
+  # it 'should create a view', ->
+  #   (expect @appendable.view).toExtend Ember.View
+
+  describe 'appending', ->
 
     it 'should append the view to the DOM', ->
-      @appendable.appendView()
+      @appendable.append()
 
       (expect @viewMock.append).toHaveBeenCalled()
 
-  describe 'remove', ->
-
-    beforeEach ->
-      @appendable.appendView()
-
-    it 'should remove the view from DOM', ->
-      @appendable.removeView()
-
-      (expect @viewMock.remove).toHaveBeenCalled()
 
   describe 'destroying', ->
 
-    it 'should call removeView method on itself', ->
-      sinon.spy @appendable, 'removeView'
+    it 'should remove the view from DOM', ->
       @appendable.destroy()
 
-      (expect @appendable.removeView).toHaveBeenCalled()
+      (expect @viewMock.remove).toHaveBeenCalled()
+
+    it 'should destroy the view', ->
+      @appendable.destroy()
+
+      (expect @viewMock.destroy).toHaveBeenCalled()

--- a/spec/javascripts/unit/slotcars/shared/lib/appendable_spec.js.coffee
+++ b/spec/javascripts/unit/slotcars/shared/lib/appendable_spec.js.coffee
@@ -19,9 +19,6 @@ describe 'Appendable', ->
     # Ember.required() just works/fires when the mixin is applied after creation
     (expect => Appendable.apply Ember.Object.create()).toThrow()
 
-  # it 'should create a view', ->
-  #   (expect @appendable.view).toExtend Ember.View
-
   describe 'appending', ->
 
     it 'should append the view to the DOM', ->

--- a/spec/javascripts/unit/slotcars/shared/lib/appendable_spec.js.coffee
+++ b/spec/javascripts/unit/slotcars/shared/lib/appendable_spec.js.coffee
@@ -3,7 +3,7 @@
 
 describe 'Appendable', ->
 
-  Appendable = Slotcars.shared.lib.Appendable
+  Appendable = slotcars.shared.lib.Appendable
 
   beforeEach ->
     @viewMock =
@@ -11,6 +11,24 @@ describe 'Appendable', ->
       remove: sinon.spy()
 
     @appendable = Ember.Object.extend(Appendable).create()
+    @appendable.view = @viewMock
 
   it 'should require a view', ->
     (expect => Appendable.apply {}).toThrow()
+
+  describe 'append to application', ->
+
+    it 'should append the view to the DOM', ->
+      @appendable.appendView()
+
+      (expect @viewMock.append).toHaveBeenCalled()
+
+  describe 'remove', ->
+
+    beforeEach ->
+      @appendable.appendView()
+
+    it 'should remove the view from DOM', ->
+      @appendable.removeView()
+
+      (expect @viewMock.remove).toHaveBeenCalled()

--- a/spec/javascripts/unit/slotcars/shared/lib/appendable_spec.js.coffee
+++ b/spec/javascripts/unit/slotcars/shared/lib/appendable_spec.js.coffee
@@ -1,0 +1,16 @@
+
+#= require slotcars/shared/lib/appendable
+
+describe 'Appendable', ->
+
+  Appendable = Slotcars.shared.lib.Appendable
+
+  beforeEach ->
+    @viewMock =
+      append: sinon.spy()
+      remove: sinon.spy()
+
+    @appendable = Ember.Object.extend(Appendable).create()
+
+  it 'should require a view', ->
+    (expect => Appendable.apply {}).toThrow()

--- a/spec/javascripts/unit/slotcars/shared/lib/appendable_spec.js.coffee
+++ b/spec/javascripts/unit/slotcars/shared/lib/appendable_spec.js.coffee
@@ -32,3 +32,11 @@ describe 'Appendable', ->
       @appendable.removeView()
 
       (expect @viewMock.remove).toHaveBeenCalled()
+
+  describe 'destroying', ->
+
+    it 'should call removeView method on itself', ->
+      sinon.spy @appendable, 'removeView'
+      @appendable.destroy()
+
+      (expect @appendable.removeView).toHaveBeenCalled()

--- a/spec/javascripts/unit/slotcars/slotcars_application_spec.js.coffee
+++ b/spec/javascripts/unit/slotcars/slotcars_application_spec.js.coffee
@@ -22,16 +22,16 @@ describe 'slotcars application screen management', ->
       @screenFactoryStub =
 
         getBuildScreen: sinon.stub().returns
-          appendToApplication: @buildScreenAppendToApplicationSpy
+          append: @buildScreenAppendToApplicationSpy
 
         getPlayScreen: sinon.stub().withArgs('42').returns
-          appendToApplication: @playScreenAppendToApplicationSpy
+          append: @playScreenAppendToApplicationSpy
 
         getTracksScreen: sinon.stub().returns
-          appendToApplication: @tracksScreenAppendToApplicationSpy
+          append: @tracksScreenAppendToApplicationSpy
 
         getHomeScreen: sinon.stub().returns
-          appendToApplication: @homeScreenAppendToApplicationSpy
+          append: @homeScreenAppendToApplicationSpy
 
       @slotcarsApplication = SlotcarsApplication.create
         screenFactory: @screenFactoryStub
@@ -65,7 +65,7 @@ describe 'slotcars application screen management', ->
       homeScreenDestroySpy = sinon.spy()
 
       @screenFactoryStub.getHomeScreen = sinon.stub().returns
-        appendToApplication: homeScreenAppendToApplicationSpy
+        append: homeScreenAppendToApplicationSpy
         destroy: homeScreenDestroySpy
 
       @slotcarsApplication.showHomeScreen()

--- a/spec/javascripts/unit/slotcars/tracks/tracks_screen_spec.js.coffee
+++ b/spec/javascripts/unit/slotcars/tracks/tracks_screen_spec.js.coffee
@@ -23,17 +23,9 @@ describe 'tracks screen', ->
   it 'should extend Ember.Object', ->
     (expect TracksScreen).toExtend Ember.Object
 
-  describe 'append to application', ->
+  it 'should create tracks screen view', ->
+    (expect @TracksScreenViewMock.create).toHaveBeenCalled()
 
-    beforeEach ->
-      @tracksScreen.appendView = sinon.spy()
-      @tracksScreen.appendToApplication()
+  it 'should create the tracks controller and provide view', ->
+    (expect @TracksControllerMock.create).toHaveBeenCalledWithAnObjectLike tracksScreenView: @TracksScreenViewMock
 
-    it 'should create the tracks controller', ->
-      (expect @TracksControllerMock.create).toHaveBeenCalled()
-
-    it 'should create the tracks screen view', ->
-      (expect @TracksScreenViewMock.create).toHaveBeenCalled()
-
-    it 'should call appendView method on itself', ->
-      (expect @tracksScreen.appendView).toHaveBeenCalled()

--- a/spec/javascripts/unit/slotcars/tracks/tracks_screen_spec.js.coffee
+++ b/spec/javascripts/unit/slotcars/tracks/tracks_screen_spec.js.coffee
@@ -23,7 +23,7 @@ describe 'tracks screen', ->
   it 'should extend Ember.Object', ->
     (expect TracksScreen).toExtend Ember.Object
 
-  describe 'appending tracks screen to application', ->
+  describe 'append to application', ->
 
     beforeEach ->
       @tracksScreen.appendView = sinon.spy()
@@ -37,14 +37,3 @@ describe 'tracks screen', ->
 
     it 'should call appendView method on itself', ->
       (expect @tracksScreen.appendView).toHaveBeenCalled()
-
-  describe 'destroying', ->
-
-    beforeEach ->
-      @TracksScreenViewMock.remove = sinon.spy()
-      @tracksScreen.appendToApplication()
-
-    it 'should tell the tracks screen view to remove itself', ->
-      @tracksScreen.destroy()
-      
-      (expect @TracksScreenViewMock.remove).toHaveBeenCalled()

--- a/spec/javascripts/unit/slotcars/tracks/tracks_screen_spec.js.coffee
+++ b/spec/javascripts/unit/slotcars/tracks/tracks_screen_spec.js.coffee
@@ -26,6 +26,7 @@ describe 'tracks screen', ->
   describe 'appending tracks screen to application', ->
 
     beforeEach ->
+      @tracksScreen.appendView = sinon.spy()
       @tracksScreen.appendToApplication()
 
     it 'should create the tracks controller', ->
@@ -34,8 +35,8 @@ describe 'tracks screen', ->
     it 'should create the tracks screen view', ->
       (expect @TracksScreenViewMock.create).toHaveBeenCalled()
 
-    it 'should append the tracks screen view', ->
-      (expect @TracksScreenViewMock.append).toHaveBeenCalled()
+    it 'should call appendView method on itself', ->
+      (expect @tracksScreen.appendView).toHaveBeenCalled()
 
   describe 'destroying', ->
 


### PR DESCRIPTION
Like discussed in issue #113 the four screens have some duplicate code. To be more general concerning the views I added a `Appendable` mixin.

The mixin has a `appendView()` and a `removeView()` method that append/remove the view which is also a part of the mixin but has to be set by the particular screen.
In addition the mixin overrides the `destroy()` method so the views are removed automatically when the screen gets destroyed.

**Other stuff:**
- I left `removeView()` public so that views can also be removed by hand. I´m not sure if we ever need it ... so maybe it should be private
- As you will recognize every screen has a private `_appendScreen()` method. All those look pretty identical. Instead we could extend the `appendView()` method of `Appendable` so that it takes a view and cares for setting the `view` property and appending the view.

How do you think about it?
