### PR TITLE
Chore/add containers and widgets

### DIFF
--- a/app/assets/javascripts/slotcars/factories/widget_factory.js.coffee
+++ b/app/assets/javascripts/slotcars/factories/widget_factory.js.coffee
@@ -1,0 +1,8 @@
+
+#= require slotcars/factories/factory
+
+Factory = Slotcars.factories.Factory
+
+(namespace 'Slotcars.factories').WidgetFactory = Factory.extend
+
+  registerWidget: (id, widgetType) -> @registerType id, widgetType

--- a/app/assets/javascripts/slotcars/shared/components/container.js.coffee
+++ b/app/assets/javascripts/slotcars/shared/components/container.js.coffee
@@ -1,0 +1,6 @@
+
+(namespace 'Slotcars.shared.components').Container = Ember.Mixin.create
+
+  view: Ember.required()
+
+  addViewAtLocation: (view, location) -> @view.set location, view

--- a/app/assets/javascripts/slotcars/shared/components/widget.js.coffee
+++ b/app/assets/javascripts/slotcars/shared/components/widget.js.coffee
@@ -1,0 +1,6 @@
+
+(namespace 'Slotcars.shared.components').Widget = Ember.Mixin.create
+
+  view: Ember.required()
+
+  addToContainerAtLocation: (container, location) -> container.addViewAtLocation @view, location

--- a/spec/javascripts/unit/slotcars/factories/widget_factory_spec.js.coffee
+++ b/spec/javascripts/unit/slotcars/factories/widget_factory_spec.js.coffee
@@ -1,0 +1,24 @@
+
+#= require slotcars/factories/factory
+#= require slotcars/factories/widget_factory
+
+describe 'Slotcars.factories.WidgetFactory', ->
+
+  Factory = Slotcars.factories.Factory
+  WidgetFactory = Slotcars.factories.WidgetFactory
+
+  it 'should be a factory', -> (expect WidgetFactory).toExtend Factory
+
+
+  describe 'registering widgets', ->
+
+      beforeEach -> @widgetFactory = WidgetFactory.create()
+
+      it 'should provide specific method for registering widgets', ->
+        registerTypeStub = sinon.stub @widgetFactory, 'registerType'
+        id = 'TestWidget'
+        testWidget = {}
+
+        @widgetFactory.registerWidget id, testWidget
+
+        (expect registerTypeStub).toHaveBeenCalledWith id, testWidget

--- a/spec/javascripts/unit/slotcars/shared/components/container_spec.js.coffee
+++ b/spec/javascripts/unit/slotcars/shared/components/container_spec.js.coffee
@@ -1,0 +1,27 @@
+
+#= require slotcars/shared/components/container
+
+describe 'Slotcars.shared.components.Container', ->
+
+  Container = Slotcars.shared.components.Container
+
+  it 'should always require a view', ->
+    # applies the Appendable mixin on an object - assumes an error when 'view' property is not set
+    # Ember.required() just works/fires when the mixin is applied after creation
+    (expect => Container.apply Ember.Object.create()).toThrow 'Required property not defined: view'
+
+
+  describe 'adding views to locations', ->
+
+    beforeEach ->
+      @containerViewMock = set: sinon.spy()
+      @viewMock = {}
+
+      @container = Ember.Object.extend(Container).create view: @containerViewMock
+
+
+    it 'should tell the container view to set the view as attribute with location name', ->
+      location = 'testLocation'
+      @container.addViewAtLocation @viewMock, location
+
+      (expect @containerViewMock.set).toHaveBeenCalledWith location, @viewMock

--- a/spec/javascripts/unit/slotcars/shared/components/container_spec.js.coffee
+++ b/spec/javascripts/unit/slotcars/shared/components/container_spec.js.coffee
@@ -8,7 +8,7 @@ describe 'Slotcars.shared.components.Container', ->
   it 'should always require a view', ->
     # applies the Appendable mixin on an object - assumes an error when 'view' property is not set
     # Ember.required() just works/fires when the mixin is applied after creation
-    (expect => Container.apply Ember.Object.create()).toThrow 'Required property not defined: view'
+    (expect => Container.apply Ember.Object.create()).toThrow()
 
 
   describe 'adding views to locations', ->

--- a/spec/javascripts/unit/slotcars/shared/components/widget_spec.js.coffee
+++ b/spec/javascripts/unit/slotcars/shared/components/widget_spec.js.coffee
@@ -8,7 +8,7 @@ describe 'Slotcars.shared.components.Widget', ->
   it 'should always require a view', ->
     # applies the Appendable mixin on an object - assumes an error when 'view' property is not set
     # Ember.required() just works/fires when the mixin is applied after creation
-    (expect => Widget.apply Ember.Object.create()).toThrow 'Required property not defined: view'
+    (expect => Widget.apply Ember.Object.create()).toThrow()
 
 
   describe 'adding widget to container', ->

--- a/spec/javascripts/unit/slotcars/shared/components/widget_spec.js.coffee
+++ b/spec/javascripts/unit/slotcars/shared/components/widget_spec.js.coffee
@@ -1,0 +1,27 @@
+
+#= require slotcars/shared/components/widget
+
+describe 'Slotcars.shared.components.Widget', ->
+
+  Widget = Slotcars.shared.components.Widget
+
+  it 'should always require a view', ->
+    # applies the Appendable mixin on an object - assumes an error when 'view' property is not set
+    # Ember.required() just works/fires when the mixin is applied after creation
+    (expect => Widget.apply Ember.Object.create()).toThrow 'Required property not defined: view'
+
+
+  describe 'adding widget to container', ->
+
+    beforeEach ->
+      @containerMock = addViewAtLocation: sinon.spy()
+      @viewMock = {}
+
+      @widget = Ember.Object.extend(Widget).create view: @viewMock
+
+
+    it 'should tell given container to add its view', ->
+      location = 'testLocation'
+      @widget.addToContainerAtLocation @containerMock, location
+
+      (expect @containerMock.addViewAtLocation).toHaveBeenCalledWith @viewMock, location


### PR DESCRIPTION
Adds containers and widgets + widget factory like discussed in  [containers and widgets wiki page](https://github.com/stravid/slotcars/wiki/Containers-and-Widgets)

These will be used for the account widget / area on the home screen that is introduced in the ajax registration feature. It enables to define certain views as Containers that have locations where widgets can be added. It is basically readability sugar around {{dynamicView}} helpers.

The widgets are handy because they can be created through the widget factory and they encapsulate their functionality. They can accept parameters on creation and tell their delegates about important events.
