### PR TITLE
Chore/integrate rest adapter

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,9 @@ source 'https://rubygems.org'
 gem 'rails', '3.2.0'
 gem 'devise' # authentication
 
+# better serialization of models
+gem "active_model_serializers", :git => "git://github.com/josevalim/active_model_serializers.git"
+
 group :assets do
   gem 'sass-rails',   '~> 3.2.3'
   gem 'coffee-rails', '~> 3.2.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,10 @@
+GIT
+  remote: git://github.com/josevalim/active_model_serializers.git
+  revision: 5f0bb6d1481478f8aea2111cc14ea286be0bfc95
+  specs:
+    active_model_serializers (0.1.0)
+      activemodel (~> 3.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -159,6 +166,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  active_model_serializers!
   coffee-rails (~> 3.2.1)
   devise
   embient (= 0.0.8)

--- a/app/assets/javascripts/slotcars.js.coffee
+++ b/app/assets/javascripts/slotcars.js.coffee
@@ -2,7 +2,6 @@
 #= require jquery_ujs
 #= require embient/ember
 #= require helpers/namespace
-#= require slotcars/factories/screen_factory
 #= require slotcars/slotcars_application
 
 slotcars.SlotcarsApplication.create()

--- a/app/assets/javascripts/slotcars/factories/factory.js.coffee
+++ b/app/assets/javascripts/slotcars/factories/factory.js.coffee
@@ -19,5 +19,5 @@ Factory.reopenClass
   instance: null
 
   # all subclasses will have their own singleton @instance because
-  # 'this' points to the class that 'get' is called on.
+  # 'this' points to the class that 'getInstance' is called on.
   getInstance: -> if @instance? then @instance else @instance = @create()

--- a/app/assets/javascripts/slotcars/shared/adapters/api_adapter.js.coffee
+++ b/app/assets/javascripts/slotcars/shared/adapters/api_adapter.js.coffee
@@ -3,12 +3,6 @@
 
 namespace 'slotcars.shared.adapters'
 
-slotcars.shared.adapters.ApiAdapter = DS.Adapter.extend
-  findAll: (store, type) ->
-    hash =
-      url: type.url
-      dataType: 'json'
-      contentType: 'application/json'
-      success: (json) -> store.loadMany type, json
+slotcars.shared.adapters.ApiAdapter = DS.RESTAdapter.extend
 
-    jQuery.ajax hash
+  namespace: 'api'

--- a/app/assets/javascripts/slotcars/shared/models/track.js.coffee
+++ b/app/assets/javascripts/slotcars/shared/models/track.js.coffee
@@ -7,7 +7,7 @@
 RaphaelPath = helpers.math.RaphaelPath
 ModelStore = slotcars.shared.models.ModelStore
 
-(namespace 'slotcars.shared.models').Track = DS.Model.extend
+Track = (namespace 'slotcars.shared.models').Track = DS.Model.extend
 
   _raphaelPath: null
   raphaelPathBinding: '_raphaelPath.path'
@@ -84,5 +84,4 @@ ModelStore = slotcars.shared.models.ModelStore
     @set 'rasterizedPath', Raphael.getSubpath (@get 'raphaelPath'), 0, rasterizedLength
 
 
-slotcars.shared.models.Track.reopenClass
-  url: 'api/tracks'
+Track.reopenClass toString: -> 'slotcars.shared.models.Track'

--- a/app/controllers/api/tracks_controller.rb
+++ b/app/controllers/api/tracks_controller.rb
@@ -4,4 +4,9 @@ class Api::TracksController < Api::ApiController
     tracks = Track.all
     render :json => tracks
   end
+
+  def show
+    track = Track.find params[:id]
+    render :json => track
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,4 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery
+  serialization_scope :current_user
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,3 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery
-  serialization_scope :current_user
 end

--- a/app/serializers/track_serializer.rb
+++ b/app/serializers/track_serializer.rb
@@ -1,0 +1,4 @@
+class TrackSerializer < ActiveModel::Serializer
+  attributes :id, :raphael, :rasterized
+
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,7 @@ Slotcars::Application.routes.draw do
   get '/play/:id' => 'slotcars#index'
 
   namespace :api do
-    resources :tracks, :only => [:index]
+    resources :tracks, :only => [:index, :show]
   end
 
 end

--- a/spec/controllers/api/tracks_controller_spec.rb
+++ b/spec/controllers/api/tracks_controller_spec.rb
@@ -17,4 +17,19 @@ describe Api::TracksController do
     end
 
   end
+
+  describe '#show' do
+
+    it 'should serialize the track with given id and return it as JSON' do
+      track = FactoryGirl.create :track
+      serializer = TrackSerializer.new track, :root => "track"
+      serialized_track = serializer.as_json
+
+      get :show, :id => track.id
+
+      response.body.should == serialized_track.to_json
+    end
+
+  end
+
 end

--- a/spec/controllers/api/tracks_controller_spec.rb
+++ b/spec/controllers/api/tracks_controller_spec.rb
@@ -2,7 +2,8 @@ require 'spec_helper'
 
 describe Api::TracksController do
 
-  let(:tracks) { FactoryGirl.create_list(:track, 10) }
+  let(:track) { FactoryGirl.create :track }
+  let(:tracks) { FactoryGirl.create_list :track, 10 }
 
   describe '#index' do
 
@@ -21,7 +22,6 @@ describe Api::TracksController do
   describe '#show' do
 
     it 'should serialize the track with given id and return it as JSON' do
-      track = FactoryGirl.create :track
       serializer = TrackSerializer.new track, :root => "track"
       serialized_track = serializer.as_json
 

--- a/spec/controllers/api/tracks_controller_spec.rb
+++ b/spec/controllers/api/tracks_controller_spec.rb
@@ -6,12 +6,13 @@ describe Api::TracksController do
 
   describe '#index' do
 
-    it 'should respond with all tracks as JSON' do
-      json_tracks = tracks.to_json
+    it 'should serialize all tracks and return them as JSON' do
+      serializer = ActiveModel::ArraySerializer.new tracks, :root => "tracks"
+      serialized_tracks = serializer.as_json
 
       get :index
 
-      response.body.should == json_tracks
+      response.body.should == serialized_tracks.to_json
       response.should be_success
     end
 

--- a/spec/javascripts/unit/slotcars/shared/adapters/api_adapter_spec.js.coffee
+++ b/spec/javascripts/unit/slotcars/shared/adapters/api_adapter_spec.js.coffee
@@ -5,39 +5,11 @@
 describe 'ApiAdapter', ->
 
   ApiAdapter = slotcars.shared.adapters.ApiAdapter
-  Track = slotcars.shared.models.Track
 
-  beforeEach ->
-    @storeMock =
-      loadMany: sinon.spy()
-    @trackMock =
-      url: 'test/url'
+  it 'should extend RESTAdapter', ->
+    (expect ApiAdapter).toExtend DS.RESTAdapter
 
-    @apiAdapter = ApiAdapter.create()
-    @xhr = sinon.useFakeXMLHttpRequest()
-    @requests = []
+  it 'should provide namespace property', ->
+    adapterInstance = ApiAdapter.create()
 
-    @xhr.onCreate = (request) => @requests.push request
-
-  afterEach ->
-    @xhr.restore()
-
-  describe '#findAll', ->
-
-    it 'should make a GET request to the specified url', ->
-      @apiAdapter.findAll @storeMock, @trackMock
-
-      (expect @requests.length).toBe 1
-      (expect @requests[0].url).toBe @trackMock.url
-      (expect @requests[0].method).toBe 'GET'
-
-    it 'should call the stores loadMany method with the JSON response', ->
-      @apiAdapter.findAll @storeMock, @trackMock
-
-      response = '[{ "id": 1 }, { "id": 2 }]'
-      @requests[0].respond 200, { 'Content-Type': 'application/json' }, response
-
-      (expect @storeMock.loadMany).toHaveBeenCalledWith @trackMock, (JSON.parse response)
-
-
-
+    (expect adapterInstance.get 'namespace').toBe 'api'

--- a/spec/javascripts/unit/slotcars/shared/models/track_spec.js.coffee
+++ b/spec/javascripts/unit/slotcars/shared/models/track_spec.js.coffee
@@ -14,8 +14,8 @@ describe 'slotcars.shared.models.Track', ->
   it 'should be a subclass of an ember-data Model', ->
     (expect Track).toExtend DS.Model
 
-  it 'should define a url', ->
-    (expect Track.url).toBeDefined()
+  it 'should provide correct namespace on toString', ->
+    (expect Track.toString()).toBe 'slotcars.shared.models.Track'
 
   beforeEach ->
     @raphaelPathMock = mockEmberClass RaphaelPath, setRaphaelPath: sinon.spy(), setRasterizedPath: sinon.spy()

--- a/spec/routing/api_routes_spec.rb
+++ b/spec/routing/api_routes_spec.rb
@@ -1,8 +1,16 @@
 describe "Tracks" do
   it "routes /api/tracks to api::tracks#index" do
     { :get => "/api/tracks" }.should route_to(
-      :controller => "api/tracks",
-      :action => "index"
-    )
+        :controller => "api/tracks",
+        :action => "index"
+      )
+  end
+
+  it "routes /api/tracks/:id to api::tracks#show with params" do
+    { :get => "/api/tracks/1" }.should route_to(
+        :controller => "api/tracks",
+        :action => "show",
+        :id => "1"
+      )
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -29,4 +29,7 @@ RSpec.configure do |config|
   # automatically. This will be the default behavior in future versions of
   # rspec-rails.
   config.infer_base_class_for_anonymous_controllers = false
+
+  # add test helpers for controllers using devise
+  config.include Devise::TestHelpers, :type => :controller
 end


### PR DESCRIPTION
Correctly integrates the RESTAdapter provided by ember-data to work with our project. On the rails side it adds the ultra awesome [active model serializers](https://github.com/josevalim/active_model_serializers) which enable clean declaration of how to serialize models to json. This also works out of the box with RESTAdapter.

The missing link was actually extending RESTAdapter and provide the correct `namespace`attribute on our ApiAdapter ('api'). RESTAdapter uses that exactly for what we want it to use ;-)

The second problem was that RESTAdapter uses the `toString` method on models to get their name to build the url. Since we fucked up with embers namespacing we have no correct toString method that would give something like `Slotcars.shared.models.Track`. So we have to add that manually by reopening the class and overriding the static toString method ourselves.

Have a lot of fun now, because this pull request just removed many hours of tedious work from us :-)
