### PR TITLE
Pull Request: chore/implement-offset-limit-api

### DIFF
--- a/app/controllers/api/tracks_controller.rb
+++ b/app/controllers/api/tracks_controller.rb
@@ -1,7 +1,12 @@
 class Api::TracksController < Api::ApiController
 
   def index
-    tracks = Track.all
+    if params.has_key?(:offset) && params.has_key?(:limit)
+      tracks = Track.offset(params[:offset]).limit(params[:limit])
+    else
+      tracks = Track.all
+    end
+
     render :json => tracks
   end
 

--- a/spec/controllers/api/tracks_controller_spec.rb
+++ b/spec/controllers/api/tracks_controller_spec.rb
@@ -17,6 +17,16 @@ describe Api::TracksController do
       response.should be_success
     end
 
+    it 'should take offset and limit into account' do
+      serializer = ActiveModel::ArraySerializer.new tracks[1..3], :root => "tracks"
+      serialized_tracks = serializer.as_json
+
+      get :index, :offset => 1, :limit => 3
+
+      response.body.should == serialized_tracks.to_json
+      response.should be_success
+    end
+
   end
 
   describe '#show' do


### PR DESCRIPTION
A pull request like a pull request should be :)

Basically this implements the `offset` and `limit` query parameters for the `TracksController`. If both are set on the `index` action we don't return all tracks, but only the requested range. This is the ground work for the paginated tracks screen feature!
