### PR TITLE
Pull Request feature/paginated-tracks-screen

### DIFF
--- a/app/assets/javascripts/slotcars/shared/views/thumbnail_track_view.js.coffee
+++ b/app/assets/javascripts/slotcars/shared/views/thumbnail_track_view.js.coffee
@@ -7,8 +7,3 @@ TrackView = slotcars.shared.views.TrackView
 
   scaleFactor: 0.38
   drawTrackOnDidInsertElement: true
-
-  didInsertElement: ->
-    @_super()
-
-    @$().on 'touchMouseUp', => slotcars.routeManager.set 'location', "play/#{@track.get 'id'}"

--- a/app/assets/javascripts/slotcars/shared/views/thumbnail_track_view.js.coffee
+++ b/app/assets/javascripts/slotcars/shared/views/thumbnail_track_view.js.coffee
@@ -4,8 +4,9 @@
 TrackView = slotcars.shared.views.TrackView
 
 (namespace 'Slotcars.shared.views').ThumbnailTrackView = TrackView.extend
-  
-  scaleFactor: 0.3
+
+  scaleFactor: 0.38
+  drawTrackOnDidInsertElement: true
 
   didInsertElement: ->
     @_super()

--- a/app/assets/javascripts/slotcars/tracks/controllers/tracks_controller.js.coffee
+++ b/app/assets/javascripts/slotcars/tracks/controllers/tracks_controller.js.coffee
@@ -1,20 +1,32 @@
 
 #= require slotcars/shared/models/track
-#= require slotcars/shared/models/model_store
 #= require slotcars/tracks/views/tracks_view
 
-ModelStore = slotcars.shared.models.ModelStore
 Track = slotcars.shared.models.Track
 TracksView = slotcars.tracks.views.TracksView
 
 (namespace 'slotcars.tracks.controllers').TracksController = Ember.Object.extend
 
   tracksScreenView: null
-  tracks: null
+
+  pageATracks: null
+  pageBTracks: null
+  pageCTracks: null
 
   init: ->
-    @tracks = ModelStore.findAll Track
     @tracksView = TracksView.create
       controller: this
+      swipeTreshhold: 100
+      currentPage: 1
+
+    @set 'pageATracks', []
+    @set 'pageBTracks', Track.find { offset: 0, limit: 4 }
+    @set 'pageCTracks', Track.find { offset: 4, limit: 4 }
 
     @tracksScreenView.set 'contentView', @tracksView
+
+  reloadPageATracks: (offset) -> @set 'pageATracks', Track.find { offset: offset, limit: 4 }
+
+  reloadPageBTracks: (offset) -> @set 'pageBTracks', Track.find { offset: offset, limit: 4 }
+
+  reloadPageCTracks: (offset) -> @set 'pageCTracks', Track.find { offset: offset, limit: 4 }

--- a/app/assets/javascripts/slotcars/tracks/controllers/tracks_controller.js.coffee
+++ b/app/assets/javascripts/slotcars/tracks/controllers/tracks_controller.js.coffee
@@ -12,21 +12,25 @@ TracksView = slotcars.tracks.views.TracksView
   pageATracks: null
   pageBTracks: null
   pageCTracks: null
+  tracksPerPage: null
 
   init: ->
+    @tracksPerPage = 4
+
     @tracksView = TracksView.create
       tracksController: this
       swipeTreshhold: 100
       currentPage: 1
+      tracksPerPage: @tracksPerPage
 
     @set 'pageATracks', []
-    @set 'pageBTracks', Track.find { offset: 0, limit: 4 }
-    @set 'pageCTracks', Track.find { offset: 4, limit: 4 }
+    @set 'pageBTracks', Track.find { offset: 0, limit: @tracksPerPage }
+    @set 'pageCTracks', Track.find { offset: 4, limit: @tracksPerPage }
 
     @tracksScreenView.set 'contentView', @tracksView
 
-  reloadPageATracks: (offset) -> @set 'pageATracks', Track.find { offset: offset, limit: 4 }
+  reloadPageATracks: (offset) -> @set 'pageATracks', Track.find { offset: offset, limit: @tracksPerPage }
 
-  reloadPageBTracks: (offset) -> @set 'pageBTracks', Track.find { offset: offset, limit: 4 }
+  reloadPageBTracks: (offset) -> @set 'pageBTracks', Track.find { offset: offset, limit: @tracksPerPage }
 
-  reloadPageCTracks: (offset) -> @set 'pageCTracks', Track.find { offset: offset, limit: 4 }
+  reloadPageCTracks: (offset) -> @set 'pageCTracks', Track.find { offset: offset, limit: @tracksPerPage }

--- a/app/assets/javascripts/slotcars/tracks/controllers/tracks_controller.js.coffee
+++ b/app/assets/javascripts/slotcars/tracks/controllers/tracks_controller.js.coffee
@@ -15,7 +15,7 @@ TracksView = slotcars.tracks.views.TracksView
 
   init: ->
     @tracksView = TracksView.create
-      controller: this
+      tracksController: this
       swipeTreshhold: 100
       currentPage: 1
 

--- a/app/assets/javascripts/slotcars/tracks/templates/page_view_template.js.hjs
+++ b/app/assets/javascripts/slotcars/tracks/templates/page_view_template.js.hjs
@@ -1,0 +1,5 @@
+{{#each tracks}}
+  <div class="track" data-track-id="{{unbound id}}">
+    {{view Slotcars.shared.views.ThumbnailTrackView trackBinding="this" class="track-container" }}
+  </div>
+{{/each}}

--- a/app/assets/javascripts/slotcars/tracks/templates/tracks_view_template.js.hjs
+++ b/app/assets/javascripts/slotcars/tracks/templates/tracks_view_template.js.hjs
@@ -1,6 +1,5 @@
-{{#each controller.tracks}}
-  <div style="background-color: rgba(0,0,0,0.3); width:320px; height:320px; margin: 10px; float: left;">
-    Track #{{id}}
-    {{view Slotcars.shared.views.ThumbnailTrackView trackBinding="this" }}
-  </div>
-{{/each}}
+<div id="swiper">
+  {{dynamicView dynamicViewPageA}}
+  {{dynamicView dynamicViewPageB}}
+  {{dynamicView dynamicViewPageC}}
+</div>

--- a/app/assets/javascripts/slotcars/tracks/views/page_view.js.coffee
+++ b/app/assets/javascripts/slotcars/tracks/views/page_view.js.coffee
@@ -1,10 +1,6 @@
 #= require slotcars/tracks/templates/page_view_template
 
-#= require helpers/namespace
-
-namespace 'slotcars.tracks.views'
-
-slotcars.tracks.views.PageView = Ember.View.extend
+(namespace 'slotcars.tracks.views').PageView = Ember.View.extend
 
   templateName: 'slotcars_tracks_templates_page_view_template'
 

--- a/app/assets/javascripts/slotcars/tracks/views/page_view.js.coffee
+++ b/app/assets/javascripts/slotcars/tracks/views/page_view.js.coffee
@@ -1,0 +1,27 @@
+#= require slotcars/tracks/templates/page_view_template
+
+#= require helpers/namespace
+
+namespace 'slotcars.tracks.views'
+
+slotcars.tracks.views.PageView = Ember.View.extend
+
+  templateName: 'slotcars_tracks_templates_page_view_template'
+
+  origin: null
+  controller: null
+
+  didInsertElement: ->
+    @moveToOrigin()
+
+    @$().css 'position', 'absolute'
+
+  moveTo: (offset) -> @$().css '-webkit-transform', "translate3d(#{@origin + offset}px,0,0)"
+
+  setOrigin: (origin) -> @set 'origin', origin
+
+  disableTransitions: -> @$().css '-webkit-transition', ''
+
+  enableTransitions: -> @$().css '-webkit-transition', '-webkit-transform 0.2s ease-in-out'
+
+  moveToOrigin: -> @moveTo 0

--- a/app/assets/javascripts/slotcars/tracks/views/page_view.js.coffee
+++ b/app/assets/javascripts/slotcars/tracks/views/page_view.js.coffee
@@ -9,7 +9,7 @@ slotcars.tracks.views.PageView = Ember.View.extend
   templateName: 'slotcars_tracks_templates_page_view_template'
 
   origin: null
-  controller: null
+  tracksController: null
 
   didInsertElement: ->
     @moveToOrigin()

--- a/app/assets/javascripts/slotcars/tracks/views/tracks_view.js.coffee
+++ b/app/assets/javascripts/slotcars/tracks/views/tracks_view.js.coffee
@@ -14,7 +14,7 @@ slotcars.tracks.views.TracksView = Ember.View.extend
   templateName: 'slotcars_tracks_templates_tracks_view_template'
   elementId: 'tracks-view'
 
-  controller: null
+  tracksController: null
   swipeTreshhold: null
   currentPage: null
 
@@ -31,18 +31,18 @@ slotcars.tracks.views.TracksView = Ember.View.extend
 
     @pageViewA = PageView.create
       origin: -1 * @width
-      controller: @controller
-      tracksBinding: 'controller.pageATracks'
+      tracksController: @tracksController
+      tracksBinding: 'tracksController.pageATracks'
 
     @pageViewB = PageView.create
       origin: 0
-      controller: @controller
-      tracksBinding: 'controller.pageBTracks'
+      tracksController: @tracksController
+      tracksBinding: 'tracksController.pageBTracks'
 
     @pageViewC = PageView.create
       origin: @width
-      controller: @controller
-      tracksBinding: 'controller.pageCTracks'
+      tracksController: @tracksController
+      tracksBinding: 'tracksController.pageCTracks'
 
     @set 'dynamicViewPageA', @pageViewA
     @set 'dynamicViewPageB', @pageViewB
@@ -123,9 +123,9 @@ slotcars.tracks.views.TracksView = Ember.View.extend
 
   loadData: (page, offset) ->
     switch page
-      when @pageViewA then @controller.reloadPageATracks offset
-      when @pageViewB then @controller.reloadPageBTracks offset
-      when @pageViewC then @controller.reloadPageCTracks offset
+      when @pageViewA then @tracksController.reloadPageATracks offset
+      when @pageViewB then @tracksController.reloadPageBTracks offset
+      when @pageViewC then @tracksController.reloadPageCTracks offset
 
   movePagesToOrigin: ->
     for page in @pages

--- a/app/assets/javascripts/slotcars/tracks/views/tracks_view.js.coffee
+++ b/app/assets/javascripts/slotcars/tracks/views/tracks_view.js.coffee
@@ -1,13 +1,142 @@
 
 #= require slotcars/shared/views/thumbnail_track_view
 #= require slotcars/tracks/templates/tracks_view_template
+#= require slotcars/tracks/views/page_view
 
 #= require helpers/namespace
 
 namespace 'slotcars.tracks.views'
 
+PageView = slotcars.tracks.views.PageView
+
 slotcars.tracks.views.TracksView = Ember.View.extend
-  controller: null
 
   templateName: 'slotcars_tracks_templates_tracks_view_template'
   elementId: 'tracks-view'
+
+  controller: null
+  swipeTreshhold: null
+  currentPage: null
+
+  swipeStart: null
+  lastSwipePosition: null
+  pages: null
+  pageViewA: null
+  pageViewB: null
+  pageViewC: null
+  width: null
+
+  didInsertElement: ->
+    @width = (@$ '#swiper').width()
+
+    @pageViewA = PageView.create
+      origin: -1 * @width
+      controller: @controller
+      tracksBinding: 'controller.pageATracks'
+
+    @pageViewB = PageView.create
+      origin: 0
+      controller: @controller
+      tracksBinding: 'controller.pageBTracks'
+
+    @pageViewC = PageView.create
+      origin: @width
+      controller: @controller
+      tracksBinding: 'controller.pageCTracks'
+
+    @set 'dynamicViewPageA', @pageViewA
+    @set 'dynamicViewPageB', @pageViewB
+    @set 'dynamicViewPageC', @pageViewC
+
+    @pages = [ @pageViewA, @pageViewB, @pageViewC ]
+
+    (@$ '#swiper').on 'touchMouseDown', (event) => @onTouchMouseDown event
+
+  onTouchMouseDown: (event) ->
+    @bindTrackSelectionHandler()
+
+    page.disableTransitions() for page in @pages
+
+    @swipeStart = event.pageX
+
+    (@$ '#swiper').on 'touchMouseMove', (event) => @onTouchMouseMove event
+    (@$ '#swiper').on 'touchMouseUp', (event) => @onTouchMouseUp event
+
+  onTouchMouseMove: (event) ->
+    @unbindTrackSelectionHandler()
+
+    @moveWithUserMovement event.pageX - @swipeStart
+
+    @lastSwipePosition = event.pageX
+
+  onTouchMouseUp: (event) ->
+    (@$ '#swiper').off 'touchMouseMove'
+    (@$ '#swiper').off 'touchMouseUp'
+
+    @onSwipeEnd @lastSwipePosition - @swipeStart
+
+  onSwipeEnd: (delta) ->
+    return if @currentPage is 1 && delta > 0
+
+    if (Math.abs delta) > @swipeTreshhold
+      @swipe delta
+    else
+      @movePagesToOrigin()
+
+  swipe: (direction) ->
+    if direction > 0 and @currentPage > 1
+      @swipeToTheRight()
+    else
+      @swipeToTheLeft()
+
+    page.moveToOrigin() for page in @pages
+
+  swipeToTheRight: ->
+    @pages[0].setOrigin 0
+    @pages[0].enableTransitions()
+
+    @pages[1].setOrigin @width
+    @pages[1].enableTransitions()
+
+    @pages[2].setOrigin -1 * @width
+
+    # load new data, decrement currentPage
+    @currentPage--
+    @loadData @pages[2], 4 * (@currentPage - 2)
+
+    @pages.unshift @pages.pop()
+
+  swipeToTheLeft: ->
+    @pages[0].setOrigin @width
+
+    @pages[1].setOrigin -1 * @width
+    @pages[1].enableTransitions()
+
+    @pages[2].setOrigin 0
+    @pages[2].enableTransitions()
+
+    # load new data, increment currentPage
+    @currentPage++
+    @loadData @pages[0], 4 * @currentPage
+
+    @pages.push @pages.shift()
+
+  loadData: (page, offset) ->
+    switch page
+      when @pageViewA then @controller.reloadPageATracks offset
+      when @pageViewB then @controller.reloadPageBTracks offset
+      when @pageViewC then @controller.reloadPageCTracks offset
+
+  movePagesToOrigin: ->
+    for page in @pages
+      page.enableTransitions()
+      page.moveToOrigin()
+
+  moveWithUserMovement: (delta) ->
+    return if @currentPage is 1 && delta > 0
+
+    page.moveTo delta for page in @pages
+
+  bindTrackSelectionHandler: -> @$().on 'touchMouseUp', '.track', -> slotcars.routeManager.set 'location', "play/#{$(this).attr 'data-track-id'}"
+
+  unbindTrackSelectionHandler: -> @$().off 'touchMouseUp', '.track'

--- a/app/assets/javascripts/slotcars/tracks/views/tracks_view.js.coffee
+++ b/app/assets/javascripts/slotcars/tracks/views/tracks_view.js.coffee
@@ -19,7 +19,7 @@ slotcars.tracks.views.TracksView = Ember.View.extend
   currentPage: null
   tracksPerPage: null
 
-  swipeStart: null
+  swipeStartPosition: null
   lastSwipePosition: null
   pages: null
   pageViewA: null
@@ -58,7 +58,7 @@ slotcars.tracks.views.TracksView = Ember.View.extend
 
     page.disableTransitions() for page in @pages
 
-    @swipeStart = event.pageX
+    @swipeStartPosition = event.pageX
 
     (@$ '#swiper').on 'touchMouseMove', (event) => @onTouchMouseMove event
     (@$ '#swiper').on 'touchMouseUp', (event) => @onTouchMouseUp event
@@ -66,7 +66,7 @@ slotcars.tracks.views.TracksView = Ember.View.extend
   onTouchMouseMove: (event) ->
     @unbindTrackSelectionHandler()
 
-    @moveWithUserMovement event.pageX - @swipeStart
+    @moveWithUserMovement event.pageX - @swipeStartPosition
 
     @lastSwipePosition = event.pageX
 
@@ -74,7 +74,7 @@ slotcars.tracks.views.TracksView = Ember.View.extend
     (@$ '#swiper').off 'touchMouseMove'
     (@$ '#swiper').off 'touchMouseUp'
 
-    @onSwipeEnd @lastSwipePosition - @swipeStart
+    @onSwipeEnd @lastSwipePosition - @swipeStartPosition
 
   onSwipeEnd: (delta) ->
     return if @currentPage is 1 && delta > 0

--- a/app/assets/javascripts/slotcars/tracks/views/tracks_view.js.coffee
+++ b/app/assets/javascripts/slotcars/tracks/views/tracks_view.js.coffee
@@ -17,6 +17,7 @@ slotcars.tracks.views.TracksView = Ember.View.extend
   tracksController: null
   swipeTreshhold: null
   currentPage: null
+  tracksPerPage: null
 
   swipeStart: null
   lastSwipePosition: null
@@ -102,7 +103,7 @@ slotcars.tracks.views.TracksView = Ember.View.extend
 
     # load new data, decrement currentPage
     @currentPage--
-    @loadData @pages[2], 4 * (@currentPage - 2)
+    @loadData @pages[2], @tracksPerPage * (@currentPage - 2)
 
     @pages.unshift @pages.pop()
 
@@ -117,7 +118,7 @@ slotcars.tracks.views.TracksView = Ember.View.extend
 
     # load new data, increment currentPage
     @currentPage++
-    @loadData @pages[0], 4 * @currentPage
+    @loadData @pages[0], @tracksPerPage * @currentPage
 
     @pages.push @pages.shift()
 

--- a/app/assets/stylesheets/slotcars.css.scss
+++ b/app/assets/stylesheets/slotcars.css.scss
@@ -5,3 +5,4 @@
 //= require views/home_screen_view
 //= require views/play_screen_view
 //= require views/build_screen_view
+//= require views/tracks_screen_view

--- a/app/assets/stylesheets/views/tracks_screen_view.css.scss
+++ b/app/assets/stylesheets/views/tracks_screen_view.css.scss
@@ -1,0 +1,20 @@
+.track {
+  float: left;
+  width: 50%;
+}
+
+.track-container {
+  width: 390px;
+  margin: 0 auto;
+}
+
+#swiper {
+  position: absolute;
+  top: 143px;
+  left: 25px;
+  width: 976px;
+  height: 600px;
+  background-color: rgba(255, 255, 255, 0.15);
+  border-radius: 30px;
+  overflow: hidden;
+}


### PR DESCRIPTION
The tracks screen now has a super awesome slider to explore all tracks. What makes it awesome? It's the awesome sauce:
- Fully hardware accelerated animations
- A fixed amount of 12 tracks in the DOM no matter how many tracks there are overall. This means the slider is fast since the number of DOM nodes doesn't grow.
- Dynamically preloads tracks for the next page visible.

Currently there are a few things not yet implemented:
- An indicator saying on which page the user currently is, plus the total amount of pages.
- Prevent sliding to the end of the tracks. Currently you can swipe to the left as long as you want even when you reached the end.
- Left / Right buttons for desktop users without a touch screen.
- Loading indicator as long as the track hasn't finished loading.

I will add all those features to Pivotal Tracker so we can estimate them :)
