### PR TITLE
Chore/introduce singleton class

### DIFF
--- a/app/assets/javascripts/slotcars/factories/factory.js.coffee
+++ b/app/assets/javascripts/slotcars/factories/factory.js.coffee
@@ -1,5 +1,9 @@
 
-Factory = (namespace 'Slotcars.factories').Factory = Ember.Object.extend
+#= require slotcars/shared/lib/singleton
+
+Singleton = Slotcars.shared.lib.Singleton
+
+Factory = (namespace 'Slotcars.factories').Factory = Singleton.extend
 
   _registeredTypes: []
 
@@ -11,13 +15,3 @@ Factory = (namespace 'Slotcars.factories').Factory = Ember.Object.extend
       @_registeredTypes[typeId].create createParamters
     else
       throw "#{typeId} was not registered in factory."
-
-# reopenClass is used here to inherit the class methods (static) and attributes
-# also to subclasses. Inside the class methods 'this' points to the class itself.
-Factory.reopenClass
-
-  instance: null
-
-  # all subclasses will have their own singleton @instance because
-  # 'this' points to the class that 'getInstance' is called on.
-  getInstance: -> if @instance? then @instance else @instance = @create()

--- a/app/assets/javascripts/slotcars/shared/lib/singleton.js.coffee
+++ b/app/assets/javascripts/slotcars/shared/lib/singleton.js.coffee
@@ -1,0 +1,12 @@
+
+Singleton = (namespace 'Slotcars.shared.lib').Singleton = Ember.Object.extend()
+
+# reopenClass is used here to inherit the class methods (static) and attributes
+# also to subclasses. Inside the class methods 'this' points to the class itself.
+Singleton.reopenClass
+
+  instance: null
+
+  # all subclasses will have their own singleton @instance because
+  # 'this' points to the class that 'getInstance' is called on.
+  getInstance: -> if @instance? then @instance else @instance = @create()

--- a/spec/javascripts/unit/slotcars/factories/factory_spec.js.coffee
+++ b/spec/javascripts/unit/slotcars/factories/factory_spec.js.coffee
@@ -1,6 +1,10 @@
-describe 'abstract factory', ->
+describe 'Slotcars.factories.Factory', ->
 
   Factory = Slotcars.factories.Factory
+  Singleton = Slotcars.shared.lib.Singleton
+
+  it 'should be a singleton', ->
+    (expect Factory).toExtend Singleton
 
   describe 'registering types and getting instances', ->
 
@@ -39,22 +43,3 @@ describe 'abstract factory', ->
 
       (expect secondInstance).toBeInstanceOf @SecondType
       (expect thirdInstance).toBeInstanceOf @ThirdType
-
-
-  describe 'getting singleton instance of factory', ->
-
-    it 'should provide a method to always retrieve the same instance', ->
-      firstInstance = Factory.getInstance()
-      secondInstance = Factory.getInstance()
-
-      (expect firstInstance).toBeInstanceOf Factory
-      (expect secondInstance).toBe firstInstance
-
-    it 'should correctly inherit static method to subclasses', ->
-      FirstFactory = Factory.extend()
-      SecondFactory = Factory.extend()
-
-      instanceOfFirstFactory = FirstFactory.getInstance()
-      instanceOfSecondFactory = SecondFactory.getInstance()
-
-      (expect instanceOfFirstFactory).not.toBe instanceOfSecondFactory

--- a/spec/javascripts/unit/slotcars/shared/lib/singleton_spec.js.coffee
+++ b/spec/javascripts/unit/slotcars/shared/lib/singleton_spec.js.coffee
@@ -1,0 +1,12 @@
+
+describe 'Slotcars.shared.lib.Singleton', ->
+
+  Singleton = Slotcars.shared.lib.Singleton
+  ClassThatExtendsSingleton = Singleton.extend()
+
+  it 'should inherit a method to always retrieve the same instance', ->
+    firstInstance = ClassThatExtendsSingleton.getInstance()
+    secondInstance = ClassThatExtendsSingleton.getInstance()
+
+    (expect firstInstance).toBeInstanceOf ClassThatExtendsSingleton
+    (expect secondInstance).toBe firstInstance


### PR DESCRIPTION
Moves the singleton logic from `Factory` in its own class that other classes can extend from. New singletons can now be created by extending `Slotcars.shared.lib.Singleton` and have a static method `getInstance` that ensures that only one instance extists!
