### PR TITLE
Pull Request: chore/remove-old-fixes

### DIFF
--- a/app/assets/javascripts/slotcars/build/build_screen.js.coffee
+++ b/app/assets/javascripts/slotcars/build/build_screen.js.coffee
@@ -58,7 +58,4 @@ Build.BuildScreen = Ember.Object.extend Shared.Appendable,
     @_super()
     @_buildScreenStateManager.destroy()
 
-  toString: -> '<Instance of Build.BuildScreen>'
-
-
 Shared.ScreenFactory.getInstance().registerScreen 'BuildScreen', Build.BuildScreen

--- a/app/assets/javascripts/slotcars/shared/models/track.js.coffee
+++ b/app/assets/javascripts/slotcars/shared/models/track.js.coffee
@@ -74,6 +74,3 @@ Shared.Track = DS.Model.extend
 
   _onRasterizationProgress: (rasterizedLength) ->
     @set 'rasterizedPath', Raphael.getSubpath (@get 'raphaelPath'), 0, rasterizedLength
-
-
-Shared.Track.reopenClass toString: -> 'Shared.Track'

--- a/app/assets/javascripts/slotcars/shared/models/user.js.coffee
+++ b/app/assets/javascripts/slotcars/shared/models/user.js.coffee
@@ -12,5 +12,3 @@ Shared.User.reopenClass
   signUp: (credentials) ->
     user = Shared.User.createRecord credentials
     Shared.ModelStore.commit()
-
-  toString: -> 'Shared.User'

--- a/spec/javascripts/unit/slotcars/shared/models/track_spec.js.coffee
+++ b/spec/javascripts/unit/slotcars/shared/models/track_spec.js.coffee
@@ -3,9 +3,6 @@ describe 'Shared.Track', ->
   it 'should be a subclass of an ember-data Model', ->
     (expect Shared.Track).toExtend DS.Model
 
-  it 'should provide correct namespace on toString', ->
-    (expect Shared.Track.toString()).toBe 'Shared.Track'
-
   beforeEach ->
     @raphaelPathMock = mockEmberClass Shared.RaphaelPath, setRaphaelPath: sinon.spy(), setRasterizedPath: sinon.spy()
 


### PR DESCRIPTION
With the new namespaces we don't need the `toString` functions anymore.

SO LETS KILL THEM
