### PR TITLE
Pull request: Bug/fix draw finishing moment - closes #122

### DIFF
--- a/app/assets/javascripts/slotcars/build/controllers/draw_controller.js.coffee
+++ b/app/assets/javascripts/slotcars/build/controllers/draw_controller.js.coffee
@@ -15,9 +15,9 @@ Build.DrawController = Ember.Object.extend
     @track.addPathPoint point
     @_lastAddedPoint = point
 
-  clearTrack: ->
-    @track.clearPath()
-
   onTouchMouseUp: ->
-    @track.cleanPath()
-    @stateManager.send 'finishedDrawing'
+    if @track.hasValidTotalLength()
+      @track.cleanPath()
+      @stateManager.send 'finishedDrawing'
+    else
+      @track.clearPath()

--- a/app/assets/javascripts/slotcars/shared/models/track.js.coffee
+++ b/app/assets/javascripts/slotcars/shared/models/track.js.coffee
@@ -44,6 +44,8 @@ Shared.Track = DS.Model.extend Shared.IdObservable,
 
   getTotalLength: -> (@get '_raphaelPath').get 'totalLength'
 
+  hasValidTotalLength: -> (@get '_raphaelPath').get('totalLength') > 400
+
   getPointAtLength: (length) -> (@get '_raphaelPath').getPointAtLength length
 
   clearPath: -> (@get '_raphaelPath').clear()

--- a/app/assets/javascripts/slotcars/shared/models/track.js.coffee
+++ b/app/assets/javascripts/slotcars/shared/models/track.js.coffee
@@ -44,7 +44,7 @@ Shared.Track = DS.Model.extend Shared.IdObservable,
 
   getTotalLength: -> (@get '_raphaelPath').get 'totalLength'
 
-  hasValidTotalLength: -> (@get '_raphaelPath').get('totalLength') > 400
+  hasValidTotalLength: -> (@get '_raphaelPath').get('totalLength') > Shared.Track.MINIMUM_TRACK_LENGTH
 
   getPointAtLength: (length) -> (@get '_raphaelPath').getPointAtLength length
 
@@ -77,3 +77,6 @@ Shared.Track = DS.Model.extend Shared.IdObservable,
 
   _onRasterizationProgress: (rasterizedLength) ->
     @set 'rasterizedPath', Raphael.getSubpath (@get 'raphaelPath'), 0, rasterizedLength
+
+Shared.Track.reopenClass
+  MINIMUM_TRACK_LENGTH: 400

--- a/spec/javascripts/unit/slotcars/build/controllers/draw_controller_spec.js.coffee
+++ b/spec/javascripts/unit/slotcars/build/controllers/draw_controller_spec.js.coffee
@@ -14,7 +14,7 @@ describe 'Build.DrawController', ->
   afterEach ->
     @buildScreenStateManagerMock.restore()
 
-  describe 'add path points to track model on mouse move', ->
+  describe 'drawing by mouse move', ->
 
     it 'should add point to model if it has enough distance from last point', ->
       testPoint = x: 9999, y: 0
@@ -36,27 +36,31 @@ describe 'Build.DrawController', ->
 
       (expect @trackMock.addPathPoint).not.toHaveBeenCalledWith testPoint
 
-  describe 'clearing the track path', ->
+  describe 'finishing drawing', ->
 
-    beforeEach ->
-      @trackMock.clearPath = sinon.spy()
+    describe 'when track length is valid', ->
 
-    it 'should tell the track model to clear path', ->
-      @drawController.clearTrack()
+      beforeEach ->
+        @trackMock.hasValidTotalLength = sinon.stub().returns true
+        @trackMock.cleanPath = sinon.spy()
 
-      (expect @trackMock.clearPath).toHaveBeenCalled()
+      it 'should clean the track on mouse up event', ->
+        @drawController.onTouchMouseUp()
 
-  describe 'cleaning the track when user finished drawing', ->
+        (expect @trackMock.cleanPath).toHaveBeenCalled()
 
-    beforeEach ->
-      @trackMock.cleanPath = sinon.spy()
+      it 'should signalize the end of drawing to the state manager', ->
+        @drawController.onTouchMouseUp()
 
-    it 'should clean the track on mouse up event', ->
-      @drawController.onTouchMouseUp()
+        (expect @buildScreenStateManagerMock.send).toHaveBeenCalledWith 'finishedDrawing'
 
-      (expect @trackMock.cleanPath).toHaveBeenCalled()
+    describe 'when track length is invalid', ->
 
-    it 'should signalize the end of drawing to the state manager', ->
-      @drawController.onTouchMouseUp()
+      beforeEach ->
+        @trackMock.hasValidTotalLength = sinon.stub().returns false
+        @trackMock.clearPath = sinon.spy()
 
-      (expect @buildScreenStateManagerMock.send).toHaveBeenCalledWith 'finishedDrawing'
+      it 'should tell the track model to clear path', ->
+        @drawController.onTouchMouseUp()
+
+        (expect @trackMock.clearPath).toHaveBeenCalled()

--- a/spec/javascripts/unit/slotcars/shared/models/track_spec.js.coffee
+++ b/spec/javascripts/unit/slotcars/shared/models/track_spec.js.coffee
@@ -46,6 +46,23 @@ describe 'Shared.Track', ->
 
       (expect totalLength).toBe expectedLength
 
+  describe 'determine if track is long enough', ->
+
+    it 'should return true if the track´s total length is higher than 400', ->
+      track = Shared.Track.createRecord()
+      @raphaelPathMock.get = sinon.stub().withArgs('totalLength').returns 400.1
+
+      isLengthValid = track.hasValidTotalLength()
+
+      (expect isLengthValid).toBe true
+
+    it 'should return false if the track´s total length is below 400', ->
+      track = Shared.Track.createRecord()
+      @raphaelPathMock.get = sinon.stub().withArgs('totalLength').returns 399.9
+
+      isLengthValid = track.hasValidTotalLength()
+
+      (expect isLengthValid).toBe false
 
   describe 'getting point on length of track', ->
 

--- a/spec/javascripts/unit/slotcars/shared/models/track_spec.js.coffee
+++ b/spec/javascripts/unit/slotcars/shared/models/track_spec.js.coffee
@@ -48,7 +48,7 @@ describe 'Shared.Track', ->
 
   describe 'determine if track is long enough', ->
 
-    it 'should return true if the track´s total length is higher than 400', ->
+    it 'should return true if the track´s total length is high enough', ->
       track = Shared.Track.createRecord()
       @raphaelPathMock.get = sinon.stub().withArgs('totalLength').returns 400.1
 
@@ -56,7 +56,7 @@ describe 'Shared.Track', ->
 
       (expect isLengthValid).toBe true
 
-    it 'should return false if the track´s total length is below 400', ->
+    it 'should return false if the track´s total length too low', ->
       track = Shared.Track.createRecord()
       @raphaelPathMock.get = sinon.stub().withArgs('totalLength').returns 399.9
 


### PR DESCRIPTION
This PR cares about the right moment to finish drawing. Until now a normal click/touch fired the `finishedDrawing` event. I introduced the `hasValidTotalLength` method on `Track`. By using this method in the draw controllers `onTouchMouseUp` it can be ensured that `finishedDrawing` is just called if the track is long enough, otherwise you have to redraw! - see #122
