### PR TITLE
Fixes the zombie car that occurs when the up handler is not called.

### DIFF
--- a/app/assets/javascripts/slotcars/shared/lib/controllable.js.coffee
+++ b/app/assets/javascripts/slotcars/shared/lib/controllable.js.coffee
@@ -8,10 +8,10 @@ Shared.Controllable = Ember.Mixin.create
 
   onCarControlsChange: (->
     @$().off 'touchMouseDown'
-    @$().off 'touchMouseUp'
+    (jQuery document).off 'touchMouseUp'
 
     if @gameController.get 'carControlsEnabled'
       @$().on 'touchMouseDown', (event) => @gameController.onTouchMouseDown event
-      @$().on 'touchMouseUp', (event) => @gameController.onTouchMouseUp event
+      (jQuery document).on 'touchMouseUp', (event) => @gameController.onTouchMouseUp event
 
   ).observes 'gameController.carControlsEnabled'


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/29530627

Should be straightforward but anyways. Since we can't bind everything to the document (buttons won't work) we only bind the up handler to the document. This way it can't happen that the up handler doesn't get called.
