### PR TITLE
PR: bug/login logout fail

### DIFF
--- a/app/assets/javascripts/slotcars/shared/models/user.js.coffee
+++ b/app/assets/javascripts/slotcars/shared/models/user.js.coffee
@@ -54,8 +54,9 @@ Shared.User.reopenClass
         type: "DELETE"
         dataType: 'json'
 
-        success: ->
+        success: (data) ->
           Shared.User.current = null
           successCallback() if successCallback?
+          (jQuery 'meta[name="csrf-token"]').attr 'content', data.new_authenticity_token
 
         error: -> errorCallback() if errorCallback?

--- a/app/controllers/api/sessions_controller.rb
+++ b/app/controllers/api/sessions_controller.rb
@@ -22,7 +22,7 @@ class Api::SessionsController < Devise::SessionsController
     signed_out = (Devise.sign_out_all_scopes ? sign_out : sign_out(resource_name))
 
     if signed_out
-      render :status => 200, :json => {}
+      render :status => 200, :json => { :new_authenticity_token => form_authenticity_token }
     else
       render :status => 400, :json => {}
     end

--- a/spec/javascripts/unit/slotcars/shared/models/user_spec.js.coffee
+++ b/spec/javascripts/unit/slotcars/shared/models/user_spec.js.coffee
@@ -139,9 +139,14 @@ describe 'Shared.User', ->
       it 'should update CSRF token meta-tag', ->
         Shared.User.signOutCurrentUser()
 
+        attrSpy = sinon.spy()
+        jQueryBackup = window.jQuery
+        window.jQuery = sinon.stub().withArgs('meta[name="csrf-token"]').returns attr: attrSpy
+
         @requests[0].respond 200, { "Content-Type": "application/json" }, @successResponseBody
 
-        (expect (jQuery 'meta[name="csrf-token"]').attr 'content').toEqual @fake_authenticity_token
+        (expect attrSpy).toHaveBeenCalledWith 'content', @fake_authenticity_token
+        window.jQuery = jQueryBackup
 
     describe 'when sign out failed', ->
 

--- a/spec/javascripts/unit/slotcars/shared/models/user_spec.js.coffee
+++ b/spec/javascripts/unit/slotcars/shared/models/user_spec.js.coffee
@@ -87,7 +87,7 @@ describe 'Shared.User', ->
         (expect errorCallback).toHaveBeenCalledOnce()
 
 
-  describe 'signin current user out', ->
+  describe 'sign out current user', ->
 
     beforeEach ->
       @xhr = sinon.useFakeXMLHttpRequest()
@@ -114,37 +114,52 @@ describe 'Shared.User', ->
 
       (expect @requests.length).toBe 0
 
-    it 'should reset current user if request was successful', ->
-      Shared.User.signOutCurrentUser()
+    describe 'when sign out succeeded', ->
 
-      @requests[0].respond 200, { "Content-Type": "application/json" }
+      beforeEach ->
+        @fake_authenticity_token = 'nfasdblgadsblewavdbahljv'
+        @successResponseBody = JSON.stringify { new_authenticity_token: @fake_authenticity_token }
 
-      (expect Shared.User.current).toBe null
+      it 'should reset current user', ->
+        Shared.User.signOutCurrentUser()
 
-    it 'should not reset current user if request had errors', ->
-      Shared.User.signOutCurrentUser()
+        @requests[0].respond 200, { "Content-Type": "application/json" }, @successResponseBody
 
-      @requests[0].respond 400, { "Content-Type": "application/json" }
+        (expect Shared.User.current).toBe null
 
-      (expect Shared.User.current).toBeInstanceOf Shared.User
+      it 'should call success callback', ->
+        successCallbackSpy = sinon.spy()
 
-    it 'should call success callback when user was signed out successfully', ->
-      successCallbackSpy = sinon.spy()
+        Shared.User.signOutCurrentUser successCallbackSpy
 
-      Shared.User.signOutCurrentUser successCallbackSpy
+        @requests[0].respond 200, { "Content-Type": "application/json" }, @successResponseBody
 
-      @requests[0].respond 200, { "Content-Type": "application/json" }
+        (expect successCallbackSpy).toHaveBeenCalledOnce()
 
-      (expect successCallbackSpy).toHaveBeenCalledOnce()
+      it 'should update CSRF token meta-tag', ->
+        Shared.User.signOutCurrentUser()
 
-    it 'should call error callback when sign out failed', ->
-      errorCallbackSpy = sinon.spy()
+        @requests[0].respond 200, { "Content-Type": "application/json" }, @successResponseBody
 
-      Shared.User.signOutCurrentUser (->), errorCallbackSpy
+        (expect (jQuery 'meta[name="csrf-token"]').attr 'content').toEqual @fake_authenticity_token
 
-      @requests[0].respond 400, { "Content-Type": "application/json" }
+    describe 'when sign out failed', ->
 
-      (expect errorCallbackSpy).toHaveBeenCalledOnce()
+      it 'should not reset current user', ->
+        Shared.User.signOutCurrentUser()
+
+        @requests[0].respond 400, { "Content-Type": "application/json" }
+
+        (expect Shared.User.current).toBeInstanceOf Shared.User
+
+      it 'should call error callback', ->
+        errorCallbackSpy = sinon.spy()
+
+        Shared.User.signOutCurrentUser (->), errorCallbackSpy
+
+        @requests[0].respond 400, { "Content-Type": "application/json" }
+
+        (expect errorCallbackSpy).toHaveBeenCalledOnce()
 
   describe '#loadHighscore', ->
 


### PR DESCRIPTION
This PR fixes the 'WARNING: Can´t verify CSRF token authenticity' bug after Login -> Logout -> Login.
After a user is successfully signed out, Devise creates a new CSRF token. This solution passes the newly created token to the client (as part of success response of a sign out) and then updates the meta tag.
