### PR TITLE
Bug/car rotates before crashing

### DIFF
--- a/app/assets/javascripts/slotcars/shared/lib/crashable.js.coffee
+++ b/app/assets/javascripts/slotcars/shared/lib/crashable.js.coffee
@@ -13,21 +13,18 @@ Shared.Crashable = Ember.Mixin.create
     throw new Error 'Crashable requires Movable' unless Shared.Movable.detect this
     throw new Error 'Crashable requires Drivable' unless Shared.Drivable.detect this
 
-  checkForCrash: (->
-    @set 'nextDirection', Shared.Vector.create from: @position, to: @nextPosition
+  checkForCrash: ->
+    @set 'nextDirection', Shared.Vector.create from: @position, to: @getNextPosition()
 
     unless @direction?
       @set 'direction', @nextDirection
     else
       if @isTooFastInCurve() then @crash() else @updateDirection()
 
-  ).observes 'nextPosition'
-
   crash: -> @set 'isCrashing', true
 
   moveCarInCrashingDirection: ->
     @slowDownCrashingCar()
-    @checkForCrashEnd()
 
     @set 'position', @calculateNextCrashingPosition @getCrashVector()
 

--- a/app/assets/javascripts/slotcars/shared/lib/crashable.js.coffee
+++ b/app/assets/javascripts/slotcars/shared/lib/crashable.js.coffee
@@ -24,11 +24,14 @@ Shared.Crashable = Ember.Mixin.create
   crash: -> @set 'isCrashing', true
 
   moveCarInCrashingDirection: ->
+    @checkForCrashEnd()
     @slowDownCrashingCar()
 
     @set 'position', @calculateNextCrashingPosition @getCrashVector()
 
   isTooFastInCurve: () ->
+    return false if @speed <= 0
+
     angle = @direction.angleFrom @nextDirection
     speedPercentageMultiplier = (@speed / @maxSpeed) + 1
 
@@ -40,7 +43,7 @@ Shared.Crashable = Ember.Mixin.create
     @set 'speed', @speed - @crashDeceleration
     @clampMinSpeed()
 
-  checkForCrashEnd: -> @set 'isCrashing', false if @speed <= 0
+  checkForCrashEnd: -> (@set 'isCrashing', false) if @speed <= 0
 
   getCrashVector: -> (@direction.normalize()).scale @speed
 

--- a/app/assets/javascripts/slotcars/shared/lib/movable.js.coffee
+++ b/app/assets/javascripts/slotcars/shared/lib/movable.js.coffee
@@ -1,13 +1,8 @@
 Shared.Movable = Ember.Mixin.create
 
   lengthAtTrack: 0
-  nextLengthAtTrack: 0
-
   position: null
-  nextPosition: null
-
   rotation: 0
-  nextRotation: 0
 
   init: ->
     @_super()
@@ -16,27 +11,21 @@ Shared.Movable = Ember.Mixin.create
   moveToStartPosition: ->
     @set 'speed', 0
     @set 'lengthAtTrack', 0
-    @set 'nextLengthAtTrack', 0
 
-    @moveToNextPosition()
+    @moveAlongTrack()
 
   moveAlongTrack: ->
-    @set 'nextLengthAtTrack', @lengthAtTrack + @speed
-    @moveToNextPosition()
+    @set 'rotation', @getNextRotation()
+    @set 'position', @getNextPosition()
+    @set 'lengthAtTrack', @getNextLengthAtTrack()
 
-  calculateNextPosition: -> @set 'nextPosition', @track.getPointAtLength @nextLengthAtTrack
+  getNextLengthAtTrack: -> @lengthAtTrack + @speed
 
-  calculateNextRotation: ->
+  getNextPosition: -> @track.getPointAtLength @getNextLengthAtTrack()
+
+  getNextRotation: ->
     previousLengthAtTrack = @lengthAtTrack - 0.1
     previousPosition = @track.getPointAtLength previousLengthAtTrack
 
-    directionToNextPosition = Shared.Vector.create from: previousPosition, to: @nextPosition
-    @set 'nextRotation', directionToNextPosition.clockwiseAngle()
-
-  moveToNextPosition: ->
-    @calculateNextPosition()
-    @calculateNextRotation()
-
-    @set 'lengthAtTrack', @nextLengthAtTrack
-    @set 'position', @nextPosition
-    @set 'rotation', @nextRotation
+    directionToNextPosition = Shared.Vector.create from: previousPosition, to: @getNextPosition()
+    directionToNextPosition.clockwiseAngle()

--- a/app/assets/javascripts/slotcars/shared/models/car.js.coffee
+++ b/app/assets/javascripts/slotcars/shared/models/car.js.coffee
@@ -20,6 +20,9 @@ Shared.Car = Ember.Object.extend Shared.Movable, Shared.Drivable, Shared.Crashab
   crossedFinishLine: false
 
   drive: (shouldAccelerate) ->
+    @checkForCrash() unless @isCrashing
+    @checkForCrashEnd()
+
     if @isCrashing
       @moveCarInCrashingDirection()
     else

--- a/app/assets/javascripts/slotcars/shared/models/car.js.coffee
+++ b/app/assets/javascripts/slotcars/shared/models/car.js.coffee
@@ -21,7 +21,6 @@ Shared.Car = Ember.Object.extend Shared.Movable, Shared.Drivable, Shared.Crashab
 
   drive: (shouldAccelerate) ->
     @checkForCrash() unless @isCrashing
-    @checkForCrashEnd()
 
     if @isCrashing
       @moveCarInCrashingDirection()

--- a/spec/javascripts/unit/slotcars/shared/lib/crashable_spec.js.coffee
+++ b/spec/javascripts/unit/slotcars/shared/lib/crashable_spec.js.coffee
@@ -93,6 +93,7 @@ describe 'Shared.Crashable', ->
 
     beforeEach ->
       @vectorMock = mockEmberClass Shared.Vector
+      sinon.stub @crashable, 'getNextPosition'
 
     afterEach -> @vectorMock.restore()
 
@@ -133,11 +134,6 @@ describe 'Shared.Crashable', ->
       @crashable.moveCarInCrashingDirection()
 
       (expect @crashable.slowDownCrashingCar).toHaveBeenCalled()
-
-    it 'should check for crash end', ->
-      @crashable.moveCarInCrashingDirection()
-
-      (expect @crashable.checkForCrashEnd).toHaveBeenCalled()
 
     it 'should calculate next crashing position', ->
       testCrashVector = {}

--- a/spec/javascripts/unit/slotcars/shared/lib/crashable_spec.js.coffee
+++ b/spec/javascripts/unit/slotcars/shared/lib/crashable_spec.js.coffee
@@ -47,6 +47,17 @@ describe 'Shared.Crashable', ->
 
       (expect @crashable.isTooFastInCurve()).toBe false
 
+    it 'should return false if speed is zero', ->
+      # formular: angle * speedPercentageMultiplier + speed * speedPercentageMultiplier
+      @crashable.set 'speed', 0
+      testAngle = 10
+      # the calculation is 10, so stay lower here so it would crash normally
+      @crashable.set 'traction', 9
+
+      @crashable.set 'direction', angleFrom: sinon.stub().returns testAngle
+
+      (expect @crashable.isTooFastInCurve()).toBe false
+
 
   describe 'updating direction', ->
 
@@ -142,6 +153,11 @@ describe 'Shared.Crashable', ->
       @crashable.moveCarInCrashingDirection()
 
       (expect @crashable.calculateNextCrashingPosition).toHaveBeenCalledWith testCrashVector
+
+    it 'should check for crash end', ->
+      @crashable.moveCarInCrashingDirection()
+
+      (expect @crashable.checkForCrashEnd).toHaveBeenCalled()
 
 
   describe 'getting next crash vector', ->

--- a/spec/javascripts/unit/slotcars/shared/models/car_spec.js.coffee
+++ b/spec/javascripts/unit/slotcars/shared/models/car_spec.js.coffee
@@ -71,24 +71,19 @@ describe 'Shared.Car', ->
         sinon.stub @car, 'moveAlongTrack'
         sinon.stub @car, 'checkForCrash'
         sinon.stub @car, 'checkForCrashEnd'
+        sinon.stub @car, 'moveCarInCrashingDirection'
 
       it 'should check for crash', ->
         @car.drive()
 
         (expect @car.checkForCrash).toHaveBeenCalled()
 
-      it 'should not check for crash while crashing', ->
+      it 'should move car in crashing direction while crashing', ->
         @car.set 'isCrashing', true
-        sinon.stub @car, 'moveCarInCrashingDirection'
 
         @car.drive()
 
-        (expect @car.checkForCrash).not.toHaveBeenCalled()
-
-      it 'should check for crash', ->
-        @car.drive()
-
-        (expect @car.checkForCrashEnd).toHaveBeenCalled()
+        (expect @car.moveCarInCrashingDirection).toHaveBeenCalled()
 
       it 'should accelerate when drive was called with true', ->
         @car.drive true

--- a/spec/javascripts/unit/slotcars/shared/models/car_spec.js.coffee
+++ b/spec/javascripts/unit/slotcars/shared/models/car_spec.js.coffee
@@ -69,6 +69,26 @@ describe 'Shared.Car', ->
       beforeEach ->
         sinon.stub @car, 'accelerate'
         sinon.stub @car, 'moveAlongTrack'
+        sinon.stub @car, 'checkForCrash'
+        sinon.stub @car, 'checkForCrashEnd'
+
+      it 'should check for crash', ->
+        @car.drive()
+
+        (expect @car.checkForCrash).toHaveBeenCalled()
+
+      it 'should not check for crash while crashing', ->
+        @car.set 'isCrashing', true
+        sinon.stub @car, 'moveCarInCrashingDirection'
+
+        @car.drive()
+
+        (expect @car.checkForCrash).not.toHaveBeenCalled()
+
+      it 'should check for crash', ->
+        @car.drive()
+
+        (expect @car.checkForCrashEnd).toHaveBeenCalled()
 
       it 'should accelerate when drive was called with true', ->
         @car.drive true
@@ -81,14 +101,17 @@ describe 'Shared.Car', ->
         (expect @car.accelerate).toHaveBeenCalledWith false
 
       it 'should move along track', ->
-        @car.drive true
+        @car.drive()
 
         (expect @car.moveAlongTrack).toHaveBeenCalled()
 
 
     describe 'while crashing', ->
 
-      beforeEach -> sinon.stub @car, 'moveCarInCrashingDirection'
+      beforeEach ->
+        sinon.stub @car, 'checkForCrash'
+        sinon.stub @car, 'checkForCrashEnd'
+        sinon.stub @car, 'moveCarInCrashingDirection'
 
       it 'should accelerate when drive was called with true', ->
         @car.set 'isCrashing', true


### PR DESCRIPTION
This PR fixes the bug that the car rotates a little bit before crashing. As a nice side effect it simplifies the movable mixin while keeping the same functionality ;-)
