### PR TITLE
Pull Request: bug/hidden-finish-line-on-page-refresh

### DIFF
--- a/app/assets/javascripts/slotcars/play/play_screen.js.coffee
+++ b/app/assets/javascripts/slotcars/play/play_screen.js.coffee
@@ -5,6 +5,9 @@
 Play.PlayScreen = Ember.Object.extend Shared.Appendable,
 
   trackId: null
+  track: null
+  car: null
+
   _playScreenStateManager: null
   _game: null
 
@@ -15,10 +18,13 @@ Play.PlayScreen = Ember.Object.extend Shared.Appendable,
     @_playScreenStateManager.send 'load'
 
   load: ->
-    @track = Shared.ModelStore.find Shared.Track, @trackId
+    @track = Shared.Track.find @trackId
     @car = Shared.Car.create track: @track
 
-    @_playScreenStateManager.send 'loaded'
+    if @track.get 'isLoaded'
+      @_playScreenStateManager.send 'loaded'
+    else
+      @track.on 'didLoad', => @_playScreenStateManager.send 'loaded'
 
   initialize: ->
     @_game = Play.Game.create

--- a/spec/javascripts/unit/slotcars/play/play_screen_spec.js.coffee
+++ b/spec/javascripts/unit/slotcars/play/play_screen_spec.js.coffee
@@ -1,7 +1,8 @@
 describe 'play screen', ->
 
   beforeEach ->
-    sinon.stub Shared.ModelStore, 'find', -> Shared.Track.createRecord()
+    @trackInstance = Shared.Track._create isLoaded: true
+    sinon.stub(Shared.Track, 'find').returns @trackInstance
 
     @playScreenViewMock = mockEmberClass Play.PlayScreenView,
       append: sinon.spy()
@@ -20,7 +21,7 @@ describe 'play screen', ->
     @playScreen = Play.PlayScreen.create()
 
   afterEach ->
-    Shared.ModelStore.find.restore()
+    Shared.Track.find.restore()
     @playScreenViewMock.restore()
     @playScreenNotificationsControllerMock.restore()
     @playScreenNotificationsViewMock.restore()
@@ -51,9 +52,20 @@ describe 'play screen', ->
 
       (expect @playScreen.car).toBeInstanceOf Shared.Car
 
-    it 'should send loaded to the play screen state manager', ->
+    it 'should send loaded to the play screen state manager immediatley if track is already loaded', ->
       @playScreen.load()
 
+      (expect @playScreenStateManagerMock.send).toHaveBeenCalledWith 'loaded'
+
+    it 'should send loaded to the play screen state manager after the track is loaded', ->
+      sinon.spy @trackInstance, 'on'
+      @trackInstance.set 'isLoaded', false
+      console.log @trackInstance.get 'isLoaded'
+
+      @playScreen.load()
+      @trackInstance.fire 'didLoad' # simulates that the track has been loaded
+
+      (expect @trackInstance.on).toHaveBeenCalledWith 'didLoad'
       (expect @playScreenStateManagerMock.send).toHaveBeenCalledWith 'loaded'
 
 


### PR DESCRIPTION
This PR prevents the `PlayScreenStateManager` to proceed unless the `Track` is loaded. This fixes the issue with the invisible finish-line.
