### PR TITLE
Pull Request: feature/quickplay

### DIFF
--- a/app/assets/javascripts/slotcars/home/templates/home_screen_view_template.js.hjs
+++ b/app/assets/javascripts/slotcars/home/templates/home_screen_view_template.js.hjs
@@ -1,4 +1,5 @@
 <ul id="home-navigation">
+    <li><a id="quickplay-button" class="override-button js-route" href="quickplay">Quickplay</a></li>
     <li><a id="tracks-button" class="override-button js-route" href="tracks">Tracks</a></li>
     <li><a id="build-button" class="override-button js-route" href="build">Build</a></li>
 </ul>

--- a/app/assets/javascripts/slotcars/play/play_screen.js.coffee
+++ b/app/assets/javascripts/slotcars/play/play_screen.js.coffee
@@ -18,7 +18,11 @@ Play.PlayScreen = Ember.Object.extend Shared.Appendable,
     @_playScreenStateManager.send 'load'
 
   load: ->
-    @track = Shared.Track.find @trackId
+    if @trackId?
+      @track = Shared.Track.find @trackId
+    else
+      @track = Shared.Track.findRandom()
+
     @car = Shared.Car.create track: @track
 
     if @track.get 'isLoaded'

--- a/app/assets/javascripts/slotcars/route_manager.js.coffee
+++ b/app/assets/javascripts/slotcars/route_manager.js.coffee
@@ -8,6 +8,10 @@ Shared.RouteManager = Ember.RouteManager.extend
     route: 'build'
     enter: (manager) -> manager.delegate.showScreen 'BuildScreen'
 
+  Quickplay: Ember.State.create
+    route: 'quickplay'
+    enter: (manager) -> manager.delegate.showScreen 'PlayScreen'
+
   Play: Ember.State.create
     route: 'play/:id'
     enter: (manager) -> 
@@ -19,5 +23,4 @@ Shared.RouteManager = Ember.RouteManager.extend
 
   Home: Ember.State.create
     route: ''
-    enter: (manager) ->
-      manager.delegate.showScreen 'HomeScreen'
+    enter: (manager) -> manager.delegate.showScreen 'HomeScreen'

--- a/app/assets/javascripts/slotcars/shared/models/track.js.coffee
+++ b/app/assets/javascripts/slotcars/shared/models/track.js.coffee
@@ -65,4 +65,24 @@ Shared.Track = DS.Model.extend Shared.Rasterizable,
     if lap > numberOfLaps then return numberOfLaps else return lap
 
 Shared.Track.reopenClass
+
   MINIMUM_TRACK_LENGTH: 400
+
+  findRandom: ->
+    randomTrack = Shared.ModelStore.materializeRecord Shared.Track, 0
+
+    jQuery.ajax "/api/tracks/random",
+      type: "GET"
+      dataType: "json"
+
+      success: (response) ->
+        trackData = response.track
+        trackIds = Shared.ModelStore.load Shared.Track, trackData
+
+        # update the 'clientId' - to ensure that the rest of the tracks data is updated properly
+        randomTrack.clientId = trackIds.clientId
+        randomTrack.send 'didChangeData'
+
+        randomTrack = Shared.ModelStore.find Shared.Track, trackData.id
+
+    randomTrack

--- a/app/assets/stylesheets/views/home_screen_view.css.scss
+++ b/app/assets/stylesheets/views/home_screen_view.css.scss
@@ -21,6 +21,13 @@
   background-repeat: no-repeat;
 }
 
+#quickplay-button {
+  width: 231px;
+  height: 66px;
+  background-image: image-url("buttons/quick-play.png");
+  background-repeat: no-repeat;
+}
+
 #tracks-button {
   width: 177px;
   height: 66px;

--- a/app/controllers/api/tracks_controller.rb
+++ b/app/controllers/api/tracks_controller.rb
@@ -35,6 +35,11 @@ class Api::TracksController < Api::ApiController
     render :json => highscores.to_json
   end
 
+  def random
+    @track = Track.order('random()').first
+    render :json => @track
+  end
+
   def count
     render :json => Track.count.to_json
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Slotcars::Application.routes.draw do
 
   get '/tracks' => 'slotcars#index'
   get '/build' => 'slotcars#index'
+  get '/quickplay' => 'slotcars#index'
   get '/play/:id' => 'slotcars#index'
 
   namespace :api do
@@ -15,6 +16,7 @@ Slotcars::Application.routes.draw do
       end
 
       collection do
+        get 'random'
         get 'count'
       end
     end

--- a/spec/controllers/api/tracks_controller_spec.rb
+++ b/spec/controllers/api/tracks_controller_spec.rb
@@ -96,6 +96,19 @@ describe Api::TracksController do
     end
   end
 
+  describe '#random' do
+
+    it 'should return a randomly chosen track' do
+      track_ids = tracks.map { |track| track.id }
+
+      get :random
+
+      responseJSON = JSON.parse response.body
+
+      track_ids.should include(responseJSON['track']['id'])
+    end
+  end
+
   describe '#count' do
 
     it 'should return the number of tracks as JSON' do

--- a/spec/javascripts/unit/slotcars/play/play_screen_spec.js.coffee
+++ b/spec/javascripts/unit/slotcars/play/play_screen_spec.js.coffee
@@ -34,13 +34,14 @@ describe 'play screen', ->
 
   describe 'creating', ->
 
-    beforeEach ->
+    it 'should create play screen view', ->
       @playScreen = Play.PlayScreen.create trackId: 1
 
-    it 'should create play screen view', ->
       (expect @playScreenViewMock.create).toHaveBeenCalled()
 
     it 'should create the play screen state manager', ->
+      @playScreen = Play.PlayScreen.create trackId: 1
+
       (expect @playScreenStateManagerMock.create).toHaveBeenCalled()
 
 
@@ -52,8 +53,7 @@ describe 'play screen', ->
         sinon.stub(Shared.Track, 'findRandom').returns @trackInstance
         @playScreen = Play.PlayScreen.create()
 
-      afterEach ->
-        Shared.Track.findRandom.restore()
+      afterEach -> Shared.Track.findRandom.restore()
 
       it 'should request a random track', ->
         @playScreen.load()
@@ -62,8 +62,7 @@ describe 'play screen', ->
 
     describe 'when track id is passed', ->
 
-      beforeEach ->
-        @playScreen = Play.PlayScreen.create trackId: 1
+      beforeEach -> @playScreen = Play.PlayScreen.create trackId: 1
 
       it 'should load a track', ->
         @playScreen.load()

--- a/spec/javascripts/unit/slotcars/route_manager_spec.js.coffee
+++ b/spec/javascripts/unit/slotcars/route_manager_spec.js.coffee
@@ -18,6 +18,11 @@ describe 'routing', ->
 
     (expect @slotcarsApplicationStub.showScreen).toHaveBeenCalledWith 'BuildScreen'
 
+  it 'should show the play screen', ->
+    @routeManager.set 'location', 'quickplay'
+
+    (expect @slotcarsApplicationStub.showScreen).toHaveBeenCalledWith 'PlayScreen'
+
   it 'should show the play screen with the correct id on /play/:id', ->
     @routeManager.set 'location', 'play/42'
 

--- a/spec/javascripts/unit/slotcars/shared/models/track_spec.js.coffee
+++ b/spec/javascripts/unit/slotcars/shared/models/track_spec.js.coffee
@@ -243,8 +243,7 @@ describe 'Shared.Track', ->
       @track = Shared.Track.createRecord
         id: 1
 
-    afterEach ->
-      @xhr.restore()
+    afterEach -> @xhr.restore()
 
     it 'should send the correct request', ->
       @track.loadHighscores ->

--- a/spec/javascripts/unit/slotcars/shared/models/track_spec.js.coffee
+++ b/spec/javascripts/unit/slotcars/shared/models/track_spec.js.coffee
@@ -261,3 +261,45 @@ describe 'Shared.Track', ->
       @requests[0].respond 200, { "Content-Type": "application/json" }, response
 
       (expect callback).toHaveBeenCalledWith JSON.parse response
+
+  describe 'finding random track', ->
+
+    beforeEach ->
+      @xhr = sinon.useFakeXMLHttpRequest()
+      @requests = []
+
+      @xhr.onCreate = (xhr) => @requests.push xhr
+
+    afterEach ->
+      @xhr.restore()
+
+    it 'should request a random track from the server', ->
+      Shared.Track.findRandom()
+
+      (expect @requests[0].url).toBe '/api/tracks/random'
+      (expect @requests[0].method).toBe 'GET'
+
+    it 'should return a track record in loading state', ->
+      record = Shared.Track.findRandom()
+
+      (expect record).toBeInstanceOf Shared.Track
+      (expect record.get 'isLoaded').toBe false
+
+    describe 'when request succeeds', ->
+
+      beforeEach ->
+        @responseJSON = track: { id: 42, raphael: 'M0,0R1,1,0,1z', rasterized: '[{"x":"1.00","y":"1.00","angle":"1.00"}]' }
+
+      it 'should load the response into the model store', ->
+        sinon.spy Shared.ModelStore, 'load'
+
+        Shared.Track.findRandom()
+        @requests[0].respond 200, { "Content-Type": "application/json" }, JSON.stringify @responseJSON
+
+        (expect Shared.ModelStore.load).toHaveBeenCalledWith Shared.Track, @responseJSON.track
+
+      it 'should update the returned track record', ->
+        record = Shared.Track.findRandom()
+        @requests[0].respond 200, { "Content-Type": "application/json" }, JSON.stringify @responseJSON
+
+        (expect record.get 'id').toEqual 42

--- a/spec/javascripts/unit/slotcars/shared/models/user_spec.js.coffee
+++ b/spec/javascripts/unit/slotcars/shared/models/user_spec.js.coffee
@@ -177,8 +177,7 @@ describe 'Shared.User', ->
       @user = Shared.User.createRecord
         id: 1
 
-    afterEach ->
-      @xhr.restore()
+    afterEach -> @xhr.restore()
 
     it 'should send the correct request', ->
       @user.loadHighscores ->

--- a/spec/routing/api_routes_spec.rb
+++ b/spec/routing/api_routes_spec.rb
@@ -29,6 +29,13 @@ describe "Tracks" do
       )
   end
 
+  it "routes GET /api/tracks/random to api::tracks#random" do
+    { :get => "/api/tracks/random" }.should route_to(
+        :controller => "api/tracks",
+        :action => "random",
+      )
+  end
+
   it "routes GET /api/tracks/count to api::tracks#count" do
     { :get => "/api/tracks/count" }.should route_to(
         :controller => "api/tracks",


### PR DESCRIPTION
This PR (re-)adds the quickplay button to the `HomeScreen`. There is now a extra route '/quickplay' for the quickplay mode. Quickplay mainly uses the `PlayScreen`. Therefore I modified the loading cycle of the play screen by checking if a track ID was passed or not. If none was passed a random track is loaded.
The random track is requested from the server through a class method (`findRandom`) of `Track`. The rest is the 'old' play screen logic.
