### PR TITLE
fixes user highscores bug, sorts them by rank and improves specs

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -23,6 +23,8 @@ class User < ActiveRecord::Base
   end
 
   def runs_grouped_by_track
+    # order('') removes the default ORDER_BY clause which solves the problem that we
+    # had to include the run.id before which resulted in duplicates in the highscores
     runs.select("track_id").group("track_id").order('').includes(:track)
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -22,24 +22,40 @@ class User < ActiveRecord::Base
     where(conditions).where(["lower(username) = :value OR lower(email) = :value", { :value => login.strip.downcase }]).first
   end
 
-  def highscores
-    user_runs = runs.select("id, track_id").group(:id, :track_id).includes(:track)
+  def runs_grouped_by_track
+    runs.select("track_id").group("track_id").order('').includes(:track)
+  end
 
-    user_highscores = []
-
-    user_runs.each do |run|
-      run.track.highscores.each_with_index do |highscore, index|
-        if highscore.user_id == self.id
-          user_highscores << {
-            :track_id => run.track.id,
-            :track_title => run.track.title,
-            :time => highscore.time,
-            :rank => index + 1
-          }
-        end
+  def highscore_on_track(track)
+    track.highscores.each_with_index do |highscore, index|
+      if highscore.user_id == self.id
+        return {
+          :track_id => track.id,
+          :track_title => track.title,
+          :time => highscore.time,
+          :rank => index + 1
+        }
       end
     end
+  end
 
-    user_highscores
+  def sort_highscores_by_rank(highscores)
+    highscores.sort! { |highscoreA, highscoreB| highscoreA[:rank] <=> highscoreB[:rank] }
+  end
+
+  def highscores_for_runs(runs)
+    highscores = []
+
+    runs.each do |run|
+      highscores << highscore_on_track(run.track)
+    end
+
+    highscores
+  end
+
+  def highscores
+    user_runs = runs_grouped_by_track
+    user_highscores = highscores_for_runs user_runs
+    sort_highscores_by_rank user_highscores
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -12,33 +12,136 @@ describe User do
   it { should validate_presence_of :username}
   it { should validate_uniqueness_of :username}
 
-  describe '#highscore' do
+  describe '#runs_grouped_by_track' do
 
-    it 'should get the correct highscores' do
-      user_a = FactoryGirl.create :user
-      user_b = FactoryGirl.create :user
+    let(:track_a) { FactoryGirl.create :track }
+    let(:track_b) { FactoryGirl.create :track }
 
-      track_a = FactoryGirl.create :track
-      track_b = FactoryGirl.create :track
-      track_c = FactoryGirl.create :track
-
+    before(:each) do
       track_a.runs.create :user_id => user.id, :time => 1
-      track_a.runs.create :user_id => user_a.id, :time => 2
-      track_a.runs.create :user_id => user_b.id, :time => 3
+      track_a.runs.create :user_id => user.id, :time => 2
 
+      track_b.runs.create :user_id => user.id, :time => 1
       track_b.runs.create :user_id => user.id, :time => 2
-      track_b.runs.create :user_id => user_a.id, :time => 1
-      track_b.runs.create :user_id => user_b.id, :time => 3
-
-      track_c.runs.create :user_id => user.id, :time => 3
-      track_c.runs.create :user_id => user_a.id, :time => 2
-      track_c.runs.create :user_id => user_b.id, :time => 1
-
-      highscores = user.highscores
-
-      highscores.should include :track_id => track_a.id, :track_title => track_a.title, :time => 1, :rank => 1
-      highscores.should include :track_id => track_b.id, :track_title => track_a.title, :time => 2, :rank => 2
-      highscores.should include :track_id => track_c.id, :track_title => track_a.title, :time => 3, :rank => 3
     end
+
+    it 'should return one run for each track even if multiple runs exist' do
+      grouped_runs = user.runs_grouped_by_track
+
+      grouped_runs.length.should == 2
+    end
+
+    it 'should include the track the run was grouped by' do
+      grouped_runs = user.runs_grouped_by_track
+
+      grouped_runs.first.track.should be_a Track
+    end
+
+  end
+
+  describe '#highscore_on_track' do
+
+    let(:track) { FactoryGirl.create :track }
+
+    it 'should return a hash with track information' do
+      track.runs.create :user_id => user.id, :time => 1
+
+      highscore = user.highscore_on_track(track)
+
+      highscore[:track_id].should == track.id
+      highscore[:track_title].should == track.title
+    end
+
+    it 'should return a hash with run time and rank' do
+      user_a = FactoryGirl.create :user
+
+      userHighscoreTime = 2
+      expectedUserRank = 2
+      track.runs.create :user_id => user.id, :time => userHighscoreTime
+      track.runs.create :user_id => user_a.id, :time => userHighscoreTime - 1
+
+      highscore = user.highscore_on_track(track)
+
+      highscore[:time].should == userHighscoreTime
+      highscore[:rank].should == expectedUserRank
+    end
+  end
+
+  describe '#sort_highscores_by_rank' do
+
+    it 'should compare the rank attributes of given hash array' do
+      bestHighscore = { :rank => 1 }
+      secondHighscore = { :rank => 2 }
+
+      unsortedHighscores = [secondHighscore, bestHighscore]
+
+      sortedHighscores = user.sort_highscores_by_rank unsortedHighscores
+
+      sortedHighscores[0].should be bestHighscore
+      sortedHighscores[1].should be secondHighscore
+    end
+
+  end
+
+  describe '#highscores_for_runs' do
+
+    it 'should return an array of highscores for given runs' do
+      firstTrack = {}
+      firstRun = double("firstRun")
+      firstRun.stub(:track) { firstTrack }
+
+      secondTrack = {}
+      secondRun = double("secondRun")
+      secondRun.stub(:track) { secondTrack }
+
+      runs = [firstRun, secondRun]
+
+      firstHighscore = {}
+      secondHighscore = {}
+
+      user.should_receive(:highscore_on_track).with(firstTrack).and_return firstHighscore
+      user.should_receive(:highscore_on_track).with(secondTrack).and_return secondHighscore
+
+      highscores = user.highscores_for_runs(runs)
+
+      highscores[0].should be firstHighscore
+      highscores[1].should be secondHighscore
+    end
+
+  end
+
+  describe '#highscores' do
+
+    before(:each) do
+      user.stub(:runs_grouped_by_track)
+      user.stub(:highscores_for_runs)
+      user.stub(:sort_highscores_by_rank)
+    end
+
+    it 'should get all runs grouped by track' do
+      user.should_receive(:runs_grouped_by_track)
+      user.highscores
+    end
+
+    it 'should get highscores for runs' do
+      runs = []
+      user.stub(:runs_grouped_by_track) { runs }
+      user.should_receive(:highscores_for_runs).with(runs)
+
+      user.highscores
+    end
+
+    it 'should sort the fetched highscores by rank and return it' do
+      highscores = []
+      sortedHighscores = []
+
+      user.stub(:highscores_for_runs) { highscores }
+      user.should_receive(:sort_highscores_by_rank).with(highscores).and_return sortedHighscores
+
+      result = user.highscores
+
+      result.should be sortedHighscores
+    end
+
   end
 end


### PR DESCRIPTION
This PR seemed to be small but revealed a bug with user highscores: If the user had multiple runs on a track the highscores would include the best one multiple times (thus -> so many highscores listed in production :wink:)

So it fixes this bug first. Then it also refactors the highscores method completely into small and understandable (and well tested) methods that work together! 

Lastly it sorts the highscores by rank, what the original intend was
