### PR TITLE
Pull Request: chore/move-ranks-calculation-to-server

### DIFF
--- a/app/assets/javascripts/slotcars/shared/models/highscores.js.coffee
+++ b/app/assets/javascripts/slotcars/shared/models/highscores.js.coffee
@@ -14,8 +14,7 @@ Shared.Highscores = Ember.Object.extend
     [startIndex, endIndex] = @_calculateIndices()
     @set 'displayedRuns', (@get 'runs')[startIndex..endIndex]
 
-  getTimeForUserId: (userId) ->
-    return run.time for run in @runs when run.user_id is userId
+  getTimeForUserId: (userId) -> return run.time for run in @runs when run.user_id is userId
 
   _calculateIndices: ->
     runs = @get 'runs'

--- a/app/assets/javascripts/slotcars/shared/models/highscores.js.coffee
+++ b/app/assets/javascripts/slotcars/shared/models/highscores.js.coffee
@@ -11,14 +11,11 @@ Shared.Highscores = Ember.Object.extend
 
     @numberOfEntriesToDisplay or= 5
 
-    @_addRankToRuns()
-
     [startIndex, endIndex] = @_calculateIndices()
     @set 'displayedRuns', (@get 'runs')[startIndex..endIndex]
 
   getTimeForUserId: (userId) ->
-    for run in @runs
-      return run.time if run.user_id is userId
+    return run.time for run in @runs when run.user_id is userId
 
   _calculateIndices: ->
     runs = @get 'runs'
@@ -49,11 +46,3 @@ Shared.Highscores = Ember.Object.extend
       endIndex = numberOfEntriesToDisplay - 1
 
     [startIndex, endIndex]
-
-  _addRankToRuns: ->
-    runsWithRank = (@get 'runs').map (run, index) ->
-      run.rank = index + 1
-
-      return run
-
-    @set 'runs', runsWithRank

--- a/app/controllers/api/tracks_controller.rb
+++ b/app/controllers/api/tracks_controller.rb
@@ -30,13 +30,12 @@ class Api::TracksController < Api::ApiController
 
   def highscores
     track = Track.find params[:id]
-    highscores = track.highscores
 
-    render :json => highscores.to_json
+    render :json => track.highscores.to_json
   end
 
   def random
-    @track = Track.order('random()').first
+    @track = Track.order('RANDOM()').first
     render :json => @track
   end
 

--- a/app/controllers/api/tracks_controller.rb
+++ b/app/controllers/api/tracks_controller.rb
@@ -35,8 +35,7 @@ class Api::TracksController < Api::ApiController
   end
 
   def random
-    @track = Track.order('RANDOM()').first
-    render :json => @track
+    render :json => Track.random
   end
 
   def count

--- a/app/models/track.rb
+++ b/app/models/track.rb
@@ -9,6 +9,9 @@ class Track < ActiveRecord::Base
   validates :title, :presence => true
 
   def highscores
-    runs.select('user_id, username, MIN(time) AS time').joins(:user).order(:time).group(:user_id, :username)
+    highscores = runs.select('user_id, username, MIN(time) AS time, RANK() OVER(ORDER BY MIN(time))').joins(:user).group(:user_id, :username)
+
+    # cast rank to integer - this is not possible in the query (sadly)
+    highscores.each { |run| run.rank = run.rank.to_i }
   end
 end

--- a/app/models/track.rb
+++ b/app/models/track.rb
@@ -1,7 +1,7 @@
 class Track < ActiveRecord::Base
   has_many :runs
   has_many :ghosts
-  belongs_to :user  
+  belongs_to :user
 
   # regualar expression assures at least 3 points
   validates :raphael, format: { with: /\AM(R?(\d{1,4}(\.\d{1,2})?),?){6,}z\z/ }
@@ -14,4 +14,9 @@ class Track < ActiveRecord::Base
     # cast rank to integer - this is not possible in the query (sadly)
     highscores.each { |run| run.rank = run.rank.to_i }
   end
+
+  def self.random
+    self.order('RANDOM()').first
+  end
+
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,5 +1,3 @@
-# Read about factories at https://github.com/thoughtbot/factory_girl
-
 FactoryGirl.define do
   factory :user do
     sequence(:username) {|n| "person#{n}" }

--- a/spec/javascripts/unit/slotcars/shared/models/highscores_spec.js.coffee
+++ b/spec/javascripts/unit/slotcars/shared/models/highscores_spec.js.coffee
@@ -1,12 +1,5 @@
 describe 'Highscores', ->
 
-  it 'should add ranks to the runs', ->
-    highscores = Shared.Highscores.create
-      runs: [{},{}]
-
-    (expect highscores.runs[0].rank).toBe 1
-    (expect highscores.runs[1].rank).toBe 2
-
   it 'should limit the displayedRuns by default to 5', ->
     highscores = Shared.Highscores.create
       runs: [{}, {}, {}, {}, {}, {}]
@@ -24,13 +17,13 @@ describe 'Highscores', ->
 
     beforeEach ->
       @runs = [
-        { user_id: 1 }
-        { user_id: 2 }
-        { user_id: 3 }
-        { user_id: 4 }
-        { user_id: 5 }
-        { user_id: 6 }
-        { user_id: 7 }
+        { user_id: 1, rank: 1 }
+        { user_id: 2, rank: 2 }
+        { user_id: 3, rank: 3 }
+        { user_id: 4, rank: 4 }
+        { user_id: 5, rank: 5 }
+        { user_id: 6, rank: 6 }
+        { user_id: 7, rank: 7 }
       ]
 
     it 'should select the runs around the current users run', ->

--- a/spec/models/track_spec.rb
+++ b/spec/models/track_spec.rb
@@ -18,7 +18,7 @@ describe Track do
     end
   end
 
-  describe 'highscores' do
+  describe '#highscores' do
     let(:track) { FactoryGirl.create :track }
 
     it 'should get the correct highscores' do
@@ -42,6 +42,17 @@ describe Track do
       highscores[2].username.should eq 'tom'
       highscores[2].time.should eq 200
       highscores[2].rank.should eq 3
+    end
+  end
+
+  describe '#random' do
+
+    it 'should choose a random track' do
+      tracks = FactoryGirl.create_list :track, 10
+
+      track = Track.random
+
+      tracks.should include(track)
     end
   end
 end

--- a/spec/models/track_spec.rb
+++ b/spec/models/track_spec.rb
@@ -35,10 +35,13 @@ describe Track do
 
       highscores[0].username.should eq 'dominik'
       highscores[0].time.should eq 50
+      highscores[0].rank.should eq 1
       highscores[1].username.should eq 'david'
       highscores[1].time.should eq 100
+      highscores[1].rank.should eq 2
       highscores[2].username.should eq 'tom'
       highscores[2].time.should eq 200
+      highscores[2].rank.should eq 3
     end
   end
 end


### PR DESCRIPTION
This PR moves the calculation of the ranks in track highscores to the server side. PostgreSQL offers a `RANK()` function which matches our needs.
Besides that I did some minor refactorings mostly concerning coding style.
