### PR TITLE
PR: bug/traffic-lights-and-ghost-info-sometimes-invisible

### DIFF
--- a/app/assets/javascripts/slotcars/play/mixins/countdownable.js.coffee
+++ b/app/assets/javascripts/slotcars/play/mixins/countdownable.js.coffee
@@ -6,7 +6,7 @@ Play.Countdownable = Ember.Mixin.create
   timers: []
 
   startCountdown: (countdownFinishedCallback) ->
-    @resetCountdown()
+    Ember.run => @resetCountdown()
 
     @timers.push Ember.run.later this, @setCountdownValue, 'second', 1000
     @timers.push Ember.run.later this, @setCountdownValue, 'third', 2000

--- a/app/assets/javascripts/slotcars/play/templates/game_view_template.js.hjs
+++ b/app/assets/javascripts/slotcars/play/templates/game_view_template.js.hjs
@@ -15,7 +15,7 @@
   {{#if ghost}}
     <div id="player-versus-ghost">
       <img id="player-portrait" src="/assets/car/car-orange.png"/>
-      <span id="text-container">
+      <p id="text-container">
         <span class="name">You</span>
         vs
         {{#if ghost.belongsToCurrentUser}}
@@ -23,7 +23,7 @@
         {{else}}
           <span class="name">{{ghost.user.username}}</span>
         {{/if}}
-      </span>
+      </p>
       <img id="ghost-portrait" src="/assets/car/car-blue.png"/>
     </div>
   {{/if}}

--- a/app/assets/javascripts/slotcars/play/templates/game_view_template.js.hjs
+++ b/app/assets/javascripts/slotcars/play/templates/game_view_template.js.hjs
@@ -3,7 +3,7 @@
   <a id="choose-track" class="override-button js-route" href="/tracks">Choose A Track</a>
   <a id="show-highscore" class="override-button" style="display: none" href="">Highscores</a>
   <a id="retry-button" class="override-button" {{action "onRestartClick"}}>Retry</a>
-  <div id="countdown" {{bindAttr class="gameController.currentCountdownClass"}}></div>
+  <div id="countdown" {{bindAttr class="gameController.isCountdownVisible:visible gameController.currentCountdownClass"}}></div>
 </div>
 
 {{#if gameController.isRaceFinished}}

--- a/app/assets/javascripts/slotcars/play/views/game_view.js.coffee
+++ b/app/assets/javascripts/slotcars/play/views/game_view.js.coffee
@@ -14,10 +14,3 @@ Play.GameView = Ember.View.extend
         gameController: @get 'gameController'
 
   ).observes 'gameController.isRaceFinished'
-
-  onCountdownVisibleChange: ( ->
-    if @gameController.get 'isCountdownVisible'
-      (@$ '#countdown').removeClass 'hidden'
-    else 
-      (@$ '#countdown').addClass 'hidden'
-  ).observes 'gameController.isCountdownVisible'

--- a/app/assets/stylesheets/views/play_screen_view.css.scss
+++ b/app/assets/stylesheets/views/play_screen_view.css.scss
@@ -210,6 +210,9 @@
   width: 255px;
   height: 92px;
   background-image: image-url("views/play/traffic-light.png");
+  display: none;
+
+  &.visible { display: block; }
 
   &.first  { background-position: 0 0; }
   &.second { background-position: 0 -91px; }

--- a/app/assets/stylesheets/views/play_screen_view.css.scss
+++ b/app/assets/stylesheets/views/play_screen_view.css.scss
@@ -248,9 +248,10 @@
 
 #player-versus-ghost {
   position: absolute;
-  top: $topbar-height + 15px;
+  top: $topbar-height;
   left: 0;
-  width: 100%;
+  height: 70px;
+  width: $screen-width;
   font-family: SansitaOneRegular;
   text-align: center;
   font-size: 20px;
@@ -262,10 +263,17 @@
     margin: 0 10px 0 10px;
   }
 
-  span#text-container {
-    position: relative;
-    top: -35px;
-    margin: 20px;
+  #text-container {
+    display: inline-block;
+    margin: 0 20px;
+    vertical-align: middle;
+  }
+
+  img {
+    display: inline-block;
+    vertical-align: middle;
+    width: 55px;
+    height: 89px;
   }
 
   #player-portrait {


### PR DESCRIPTION
This PR adds a height to the ghost info and the car graphics displayed inside it because I sometimes just saw a litte part of the text and no cars.

To force immediate updating of the traffic lights visibility (and the visibility of the ghost info) I used `Ember.run` so that everything inside the `resetCountdown` method is executed in one run loop. This fixes the hidden-traffic-lights-bug for me.

Please try on your machines.
