### PR TITLE
PR: bug/buildscreen-signup-breaks-application

### DIFF
--- a/app/assets/javascripts/slotcars/account/templates/sign_up_view_template.js.hjs
+++ b/app/assets/javascripts/slotcars/account/templates/sign_up_view_template.js.hjs
@@ -28,7 +28,7 @@
   </div>
 
   <div class="form-buttons">
-    <button class="ok" {{action "onSignUpButtonClicked"}}>Create Account</button>
+    <button class="ok" type="submit">Create Account</button>
     {{#if showCancelButton}}<button class="cancel" {{action "onCancelSignUpButtonClicked"}}>Cancel</button>{{/if}}
   </div>
 </form>

--- a/app/assets/javascripts/slotcars/account/widgets/sign_up_widget.js.coffee
+++ b/app/assets/javascripts/slotcars/account/widgets/sign_up_widget.js.coffee
@@ -4,10 +4,13 @@
 
 Account.SignUpWidget = Ember.Object.extend Shared.Widget, Ember.Evented,
 
-  init: -> @set 'view', Account.SignUpView.create delegate: this
   userToSignUp: null
 
-  cancelSignUp: -> @fire 'signUpCancelled'
+  init: -> @set 'view', Account.SignUpView.create delegate: this
+
+  cancelSignUp: ->
+    @userToSignUp.deleteRecord() if @userToSignUp?
+    @fire 'signUpCancelled'
 
   signUpUserWithCredentials: (credentials) -> @set 'userToSignUp', Shared.User.signUp credentials
 

--- a/app/assets/javascripts/slotcars/build/views/authorization_view.js.coffee
+++ b/app/assets/javascripts/slotcars/build/views/authorization_view.js.coffee
@@ -27,7 +27,7 @@ Build.AuthorizationView = Shared.TrackView.extend Shared.Container,
     loginWidget.addToContainerAtLocation this, 'content'
     loginWidget.on 'signInSuccessful', this, 'onSuccessfulSignIn'
 
-    @set 'showSignUpButton', false
+    @set 'showSignUpButton', true
 
     (@view.get 'content').set 'showCancelButton', false
     (@view.get 'content').set 'texts',

--- a/app/assets/javascripts/slotcars/shared/models/user.js.coffee
+++ b/app/assets/javascripts/slotcars/shared/models/user.js.coffee
@@ -27,8 +27,9 @@ Shared.User.reopenClass
   current: null
 
   signUp: (credentials) ->
-    userToSignUp = Shared.User.createRecord credentials
-    Shared.ModelStore.commit()
+    transaction = Shared.ModelStore.transaction()
+    userToSignUp = transaction.createRecord Shared.User, credentials
+    transaction.commit()
 
     return userToSignUp
 

--- a/app/assets/stylesheets/views/build_screen_view.css.scss
+++ b/app/assets/stylesheets/views/build_screen_view.css.scss
@@ -98,7 +98,7 @@
     float: left;
 
     &.authorization-cancel-button {
-      margin-left: 0px;
+      margin-left: 12px;
     }
   }
 

--- a/spec/javascripts/unit/slotcars/shared/models/user_spec.js.coffee
+++ b/spec/javascripts/unit/slotcars/shared/models/user_spec.js.coffee
@@ -3,29 +3,36 @@ describe 'Shared.User', ->
   describe 'signup user with credentials', ->
 
     beforeEach ->
-      sinon.stub Shared.User, 'createRecord'
-      sinon.stub Shared.ModelStore, 'commit'
+      @transactionStub =
+        createRecord: sinon.stub()
+        commit: sinon.stub()
+
+      sinon.stub(Shared.ModelStore, 'transaction').returns @transactionStub
 
     afterEach ->
-      Shared.User.createRecord.restore()
-      Shared.ModelStore.commit.restore()
+      Shared.ModelStore.transaction.restore()
+
+    it 'should create a new transaction', ->
+      Shared.User.signUp()
+
+      (expect Shared.ModelStore.transaction).toHaveBeenCalled()
 
     it 'should create a new user record with credentials', ->
       credentials = {}
 
       Shared.User.signUp credentials
 
-      (expect Shared.User.createRecord).toHaveBeenCalledWith credentials
+      (expect @transactionStub.createRecord).toHaveBeenCalledWith Shared.User, credentials
 
-    it 'should tell model store to commit record', ->
+    it 'should commit the created transaction', ->
       Shared.User.signUp()
 
-      (expect Shared.ModelStore.commit).toHaveBeenCalledOnce()
+      (expect @transactionStub.commit).toHaveBeenCalledOnce()
 
     it 'should return created user model', ->
       createdUser = {}
 
-      Shared.User.createRecord.returns createdUser
+      @transactionStub.createRecord.returns createdUser
 
       returnedUser = Shared.User.signUp()
 


### PR DESCRIPTION
This PR re-adds the ability to sign up before publishing a new track.
The solution to not commit the `Track` instance to early was to create a extra transaction which just commits the creation of the `User` instance.
