### PR TITLE
Prevent scrolling with the spacebar

### DIFF
--- a/app/assets/javascripts/slotcars/shared/controllers/base_game_controller.js.coffee
+++ b/app/assets/javascripts/slotcars/shared/controllers/base_game_controller.js.coffee
@@ -25,10 +25,12 @@ Shared.BaseGameController = Ember.Object.extend
 
   onKeyDown: (event) ->
     if event.keyCode is 32
+      event.preventDefault()
       @isTouchMouseDown = true
 
   onKeyUp: (event) ->
     if event.keyCode is 32
+      event.preventDefault()
       @isTouchMouseDown = false
 
   start: -> @gameLoopController.start => @update()

--- a/spec/javascripts/unit/slotcars/shared/controllers/base_game_controller_spec.js.coffee
+++ b/spec/javascripts/unit/slotcars/shared/controllers/base_game_controller_spec.js.coffee
@@ -93,7 +93,9 @@ describe 'base game controller', ->
 
   describe '#onKeyDown', ->
     beforeEach ->
-      @correctEvent = keyCode: 32
+      @correctEvent =
+        keyCode: 32
+        preventDefault: sinon.spy()
       @incorrectEvent = keyCode: 42
       @baseGameController.isTouchMouseDown = false
 
@@ -107,9 +109,16 @@ describe 'base game controller', ->
 
       (expect @baseGameController.isTouchMouseDown).toBe false
 
+    it 'prevents scrolling with the spacebar', ->
+      @baseGameController.onKeyDown @correctEvent
+
+      (expect @correctEvent.preventDefault).toHaveBeenCalled()
+
   describe '#onKeyUp', ->
     beforeEach ->
-      @correctEvent = keyCode: 32
+      @correctEvent =
+        keyCode: 32
+        preventDefault: sinon.spy()
       @incorrectEvent = keyCode: 42
       @baseGameController.isTouchMouseDown = true
 
@@ -122,3 +131,8 @@ describe 'base game controller', ->
       @baseGameController.onKeyUp @incorrectEvent
 
       (expect @baseGameController.isTouchMouseDown).toBe true
+
+    it 'prevents scrolling with the spacebar', ->
+      @baseGameController.onKeyDown @correctEvent
+
+      (expect @correctEvent.preventDefault).toHaveBeenCalled()


### PR DESCRIPTION
The spacebar control had the problem, that it would scroll the content if the browser window was to small. By calling `event.preventDefault()` this is prevented.
