### PR TITLE
Feature/quickplay button in playscreen

### DIFF
--- a/app/assets/javascripts/slotcars/play/game.js.coffee
+++ b/app/assets/javascripts/slotcars/play/game.js.coffee
@@ -24,7 +24,6 @@ Play.Game = Shared.BaseGame.extend
     @_ghostView = Play.GhostView.create()
     @_gameController.ghostView = @_ghostView
 
-
   _applyMixins: ->
     @_super()
     Play.Finishable.apply @_trackView
@@ -34,3 +33,15 @@ Play.Game = Shared.BaseGame.extend
     @_baseGameViewContainer.set 'clockView', @_clockView
     @_baseGameViewContainer.set 'gameView', @_gameView
     @_baseGameViewContainer.set 'ghostView', @_ghostView
+
+  _removeViews: ->
+    @_super()
+    @_baseGameViewContainer.set 'clockView', null
+    @_baseGameViewContainer.set 'gameView', null
+    @_baseGameViewContainer.set 'ghostView', null
+
+  _destroyViews: ->
+    @_super()
+    @_clockView.destroy()
+    @_gameView.destroy()
+    @_ghostView.destroy()

--- a/app/assets/javascripts/slotcars/play/play_screen.js.coffee
+++ b/app/assets/javascripts/slotcars/play/play_screen.js.coffee
@@ -24,10 +24,12 @@ Play.PlayScreen = Ember.Object.extend
 
     @car = Shared.Car.create track: @track
 
-    if @track.get 'isLoaded'
-      @_playScreenStateManager.send 'loaded'
-    else
-      @track.on 'didLoad', => @_playScreenStateManager.send 'loaded'
+    if @track.get 'isLoaded' then @_onTrackLoaded()
+    else @track.on 'didLoad', => @_onTrackLoaded()
+
+  _onTrackLoaded: ->
+    @_playScreenStateManager.send 'loaded'
+    Shared.routeManager.updateLocation 'play/' + @track.get 'id'
 
   initialize: ->
     @_game = Play.Game.create
@@ -49,9 +51,11 @@ Play.PlayScreen = Ember.Object.extend
     @_game.start()
 
   destroy: ->
-    @_super()
+    @car.destroy()
+    @_playScreenStateManager.destroy()
     @_game.destroy() if @_game?
     @_playScreenNotificationsController.destroy() if @_playScreenNotificationsController?
     @_playScreenNotificationsView.destroy() if @_playScreenNotificationsView?
+    @_super()
 
 Shared.ScreenFactory.getInstance().registerScreen 'PlayScreen', Play.PlayScreen

--- a/app/assets/javascripts/slotcars/play/templates/game_view_template.js.hjs
+++ b/app/assets/javascripts/slotcars/play/templates/game_view_template.js.hjs
@@ -2,6 +2,7 @@
   <a id="home-button" class="override-button js-route" href="">Home</a>
   <a id="choose-track" class="override-button js-route" href="tracks">Choose A Track</a>
   <a id="show-highscore" class="override-button" style="display: none" href="">Highscores</a>
+  <a id="quickplay-button" class="override-button" {{action onQuickplayClick}}>Quickplay</a>
   <a id="retry-button" class="override-button" {{action "onRestartClick"}}>Retry</a>
   <div id="countdown" {{bindAttr class="view.gameController.isCountdownVisible:visible view.gameController.currentCountdownClass"}}></div>
 </div>

--- a/app/assets/javascripts/slotcars/play/views/game_view.js.coffee
+++ b/app/assets/javascripts/slotcars/play/views/game_view.js.coffee
@@ -8,6 +8,8 @@ Play.GameView = Ember.View.extend
   onRestartClick: ->
     @gameController.restartGame()
 
+  onQuickplayClick: -> Shared.routeManager.send 'quickplay'
+
   onRaceStatusChange: ( ->
     if @gameController.get 'isRaceFinished'
       @set 'overlayView', Play.ResultView.create

--- a/app/assets/javascripts/slotcars/shared/lib/base_game.js.coffee
+++ b/app/assets/javascripts/slotcars/shared/lib/base_game.js.coffee
@@ -36,11 +36,20 @@ Shared.BaseGame = Ember.Object.extend
   _appendViews: ->
     @_baseGameViewContainer.set 'trackView', @_trackView
     @_baseGameViewContainer.set 'carView', @_carView
-
     @screenView.set 'contentView', @_baseGameViewContainer
 
-  destroy: ->
-    @_baseGameViewContainer.destroy()
+  _removeViews: ->
+    @_baseGameViewContainer.set 'trackView', null
+    @_baseGameViewContainer.set 'carView', null
     @screenView.set 'contentView', null
+
+  _destroyViews: ->
+    @_carView.destroy()
+    @_trackView.destroy()
+    @_baseGameViewContainer.destroy()
+
+  destroy: ->
+    @_removeViews()
+    @_destroyViews()
     @_gameController.destroy()
     @_super()

--- a/app/assets/javascripts/slotcars/shared/lib/route_manager.js.coffee
+++ b/app/assets/javascripts/slotcars/shared/lib/route_manager.js.coffee
@@ -1,41 +1,40 @@
+Shared.RouteState = Ember.State.extend
+  exit: (manager) -> manager.delegate.destroyCurrentScreen()
+
 Shared.RouteManager = Ember.RouteManager.extend
 
   wantsHistory: true # use html5 push state
   baseURI: window.location.origin || ( window.location.protocol + "//" + window.location.host )
   delegate: null
 
-  Build: Ember.State.create
+  Build: Shared.RouteState.create
     route: 'build'
     enter: (manager) -> manager.delegate.showScreen 'BuildScreen'
 
-  Quickplay: Ember.State.create
+  Quickplay: Shared.RouteState.create
     route: 'quickplay'
     enter: (manager) -> Ember.run.later ( => manager.delegate.showScreen 'PlayScreen' ), 500
     quickplay: (manager) ->
       manager.delegate.destroyCurrentScreen()
       Ember.run.later ( => manager.delegate.showScreen 'PlayScreen' ), 500
 
-  Play: Ember.State.create
+  Play: Shared.RouteState.create
     route: 'play/:id'
     enter: (manager) ->
       manager.delegate.showScreen 'PlayScreen', trackId: (parseInt manager.getPath 'params.id')
     quickplay: (manager) -> manager.transitionTo 'Quickplay'
 
-  Tracks: Ember.State.create
+  Tracks: Shared.RouteState.create
     route: 'tracks'
     enter: (manager) -> manager.delegate.showScreen 'TracksScreen'
 
-  Error: Ember.State.create
+  Error: Shared.RouteState.create
     route: 'error'
     enter: (manager) -> manager.delegate.showScreen 'ErrorScreen'
 
-  Home: Ember.State.create
+  Home: Shared.RouteState.create
     route: ''
     enter: (manager) -> manager.delegate.showScreen 'HomeScreen'
 
   404: Ember.State.create
-    enter: (manager) ->
-      manager.allowLocationUpdate()
-      manager.set 'location', 'error'
-
-  allowLocationUpdate: -> @_skipPush = false
+    enter: (manager) -> manager.transitionTo 'Error'

--- a/app/assets/javascripts/slotcars/shared/lib/route_manager.js.coffee
+++ b/app/assets/javascripts/slotcars/shared/lib/route_manager.js.coffee
@@ -10,12 +10,16 @@ Shared.RouteManager = Ember.RouteManager.extend
 
   Quickplay: Ember.State.create
     route: 'quickplay'
-    enter: (manager) -> manager.delegate.showScreen 'PlayScreen'
+    enter: (manager) -> Ember.run.later ( => manager.delegate.showScreen 'PlayScreen' ), 500
+    quickplay: (manager) ->
+      manager.delegate.destroyCurrentScreen()
+      Ember.run.later ( => manager.delegate.showScreen 'PlayScreen' ), 500
 
   Play: Ember.State.create
     route: 'play/:id'
-    enter: (manager) -> 
+    enter: (manager) ->
       manager.delegate.showScreen 'PlayScreen', trackId: (parseInt manager.getPath 'params.id')
+    quickplay: (manager) -> manager.transitionTo 'Quickplay'
 
   Tracks: Ember.State.create
     route: 'tracks'

--- a/app/assets/javascripts/slotcars/shared/views/base_game_view_container.js.coffee
+++ b/app/assets/javascripts/slotcars/shared/views/base_game_view_container.js.coffee
@@ -7,10 +7,3 @@ Shared.BaseGameViewContainer = Ember.View.extend
   ghostView: null
   clockView: null
   gameView: null
-
-  destroy: ->
-    @trackView.destroy() if @trackView
-    @carView.destroy() if @carView
-    @clockView.destroy() if @clockView
-    @gameView.destroy() if @gameView
-    @_super()

--- a/app/assets/javascripts/slotcars/slotcars_application.js.coffee
+++ b/app/assets/javascripts/slotcars/slotcars_application.js.coffee
@@ -27,8 +27,7 @@ window.SlotcarsApplication = Ember.Application.extend
     event.originalEvent.preventDefault() # prevent scrolling on the iPad
 
   showScreen: (screenId, createParamters) ->
-    @_destroyCurrentScreen()
     @_currentScreen = Shared.ScreenFactory.getInstance().getInstanceOf screenId, createParamters
     @_currentScreen.append()
 
-  _destroyCurrentScreen: -> @_currentScreen.destroy() if @_currentScreen
+  destroyCurrentScreen: -> @_currentScreen.destroy() if @_currentScreen?

--- a/app/assets/stylesheets/views/play_screen_view.css.scss
+++ b/app/assets/stylesheets/views/play_screen_view.css.scss
@@ -38,6 +38,21 @@
     &:hover, &:focus { background-position: 0 -63px; }
   }
 
+  #quickplay-button {
+    width: 163px;
+    height: 64px;
+
+    position: absolute;
+    top: 22px;
+    right: 100px;
+
+    background-image: image-url("shared/buttons/quickplay.png");
+    background-repeat: no-repeat;
+    cursor: pointer;
+
+    &:hover, &:focus { background-position: 0 -63.5px; }
+  }
+
   #show-highscore {
     width: 188px;
     height: 63px;

--- a/spec/javascripts/unit/slotcars/play/game_spec.js.coffee
+++ b/spec/javascripts/unit/slotcars/play/game_spec.js.coffee
@@ -18,6 +18,7 @@ describe 'Play.Game', ->
     @CarViewMock = mockEmberClass Play.CarView
     @GameViewMock = mockEmberClass Play.GameView
     @ClockViewMock = mockEmberClass Play.ClockView
+    @GhostViewMock = mockEmberClass Play.GhostView
     @BaseGameViewContainerMock = mockEmberClass Shared.BaseGameViewContainer, set: sinon.spy()
 
     @game = Play.Game.create
@@ -33,6 +34,7 @@ describe 'Play.Game', ->
     @CarViewMock.restore()
     @GameViewMock.restore()
     @ClockViewMock.restore()
+    @GhostViewMock.restore()
     @BaseGameViewContainerMock.restore()
 
   describe 'creating the game', ->
@@ -46,8 +48,42 @@ describe 'Play.Game', ->
     it 'should create a game view and provide a game controller', ->
       (expect @GameViewMock.create).toHaveBeenCalledWithAnObjectLike gameController: @GameControllerMock
 
+    it 'should create a clock view and provide necessary dependencies', ->
+      (expect @ClockViewMock.create).toHaveBeenCalledWithAnObjectLike
+        gameController: @GameControllerMock
+        car: @carMock
+        track: @trackMock
+
+    it 'should create a ghost view', ->
+      (expect @GhostViewMock.create).toHaveBeenCalled()
+
     it 'should append game view to base game view container', ->
       (expect @BaseGameViewContainerMock.set).toHaveBeenCalledWith 'gameView', @GameViewMock
 
     it 'should append clock view to base game view container', ->
       (expect @BaseGameViewContainerMock.set).toHaveBeenCalledWith 'clockView', @ClockViewMock
+
+    it 'should append ghost view to base game view container', ->
+      (expect @BaseGameViewContainerMock.set).toHaveBeenCalledWith 'ghostView', @GhostViewMock
+
+  describe 'destroying the game', ->
+
+    beforeEach ->
+      sinon.spy @GameControllerMock, 'destroy'
+      sinon.spy @GhostViewMock, 'destroy'
+      sinon.spy @GameViewMock, 'destroy'
+      sinon.spy @ClockViewMock, 'destroy'
+
+      @game.destroy()
+
+    it 'should destroy the game controller', ->
+      (expect @GameControllerMock.destroy).toHaveBeenCalled()
+
+    it 'should destroy the ghost view', ->
+      (expect @GhostViewMock.destroy).toHaveBeenCalled()
+
+    it 'should destroy the clock view', ->
+      (expect @ClockViewMock.destroy).toHaveBeenCalled()
+
+    it 'should destroy the game view', ->
+      (expect @GameViewMock.destroy).toHaveBeenCalled()

--- a/spec/javascripts/unit/slotcars/play/views/game_view_spec.js.coffee
+++ b/spec/javascripts/unit/slotcars/play/views/game_view_spec.js.coffee
@@ -6,7 +6,7 @@ describe 'Play.GameView (unit)', ->
 
     @gameView = Play.GameView.create
       gameController: @gameControllerMock
-        
+
   afterEach ->
     @resultViewMock.restore()
     @gameControllerMock.restore()
@@ -16,9 +16,19 @@ describe 'Play.GameView (unit)', ->
 
   it 'should restart game when button was clicked', ->
     @gameControllerMock.restartGame = sinon.spy()
+
     @gameView.onRestartClick()
-    
+
     (expect @gameControllerMock.restartGame).toHaveBeenCalled()
+
+  it 'should send a message to the route manager when quickplay button was clicked', ->
+    Shared.routeManager = mockEmberClass Shared.RouteManager, send: sinon.spy()
+
+    @gameView.onQuickplayClick()
+
+    (expect Shared.routeManager.send).toHaveBeenCalledWith 'quickplay'
+
+    Shared.routeManager.restore()
 
   describe 'when race finishes', ->
 

--- a/spec/javascripts/unit/slotcars/shared/lib/base_game_spec.js.coffee
+++ b/spec/javascripts/unit/slotcars/shared/lib/base_game_spec.js.coffee
@@ -80,20 +80,32 @@ describe 'Shared.BaseGame', ->
   describe 'destroying the game', ->
 
     beforeEach ->
-      @BaseGameControllerMock.destroy = sinon.spy()
-      @BaseGameViewContainerMock.destroy = sinon.spy()
+      sinon.spy @BaseGameControllerMock, 'destroy'
+      sinon.spy @BaseGameViewContainerMock, 'destroy'
+      sinon.spy @TrackViewMock, 'destroy'
+      sinon.spy @CarViewMock, 'destroy'
 
     it 'should unset the content view on build screen view', ->
       @baseGame.destroy()
 
       (expect @screenViewMock.set).toHaveBeenCalledWith 'contentView', null
 
-    it 'should tell the view container to destroy itself', ->
+    it 'should destroy the base game view container', ->
       @baseGame.destroy()
 
       (expect @BaseGameViewContainerMock.destroy).toHaveBeenCalled()
 
-    it 'should call destroy on the game controller', ->
+    it 'should destroy the game controller', ->
       @baseGame.destroy()
 
       (expect @BaseGameControllerMock.destroy).toHaveBeenCalled()
+
+    it 'should destroy the car view', ->
+      @baseGame.destroy()
+
+      (expect @CarViewMock.destroy).toHaveBeenCalled()
+
+    it 'should destroy the track view', ->
+      @baseGame.destroy()
+
+      (expect @TrackViewMock.destroy).toHaveBeenCalled()

--- a/spec/javascripts/unit/slotcars/shared/lib/route_manager_spec.js.coffee
+++ b/spec/javascripts/unit/slotcars/shared/lib/route_manager_spec.js.coffee
@@ -1,8 +1,10 @@
 describe 'route manager', ->
 
   beforeEach ->
-    @slotcarsApplicationStub = showScreen: sinon.spy()
     sinon.stub Ember.run, 'later'
+    @slotcarsApplicationStub =
+      showScreen: sinon.spy()
+      destroyCurrentScreen: sinon.spy()
     @routeManager = Shared.RouteManager.create delegate: @slotcarsApplicationStub
 
   afterEach ->
@@ -70,3 +72,18 @@ describe 'route manager', ->
 
     (expect @routeManager.transitionTo).toHaveBeenCalledWith 'Quickplay'
 
+describe 'route state', ->
+
+  describe 'leaving the state', ->
+    beforeEach ->
+      @routeState = Shared.RouteState.create()
+      @slotcarsApplicationStub = destroyCurrentScreen: sinon.spy()
+      @RouteManagerMock = mockEmberClass Shared.RouteManager,
+        delegate: @slotcarsApplicationStub
+
+    afterEach -> @RouteManagerMock.restore()
+
+    it 'should call destroy the current screen', ->
+      @routeState.exit @RouteManagerMock
+
+      (expect @slotcarsApplicationStub.destroyCurrentScreen).toHaveBeenCalled()

--- a/spec/javascripts/unit/slotcars/shared/views/base_game_view_container_spec.js.coffee
+++ b/spec/javascripts/unit/slotcars/shared/views/base_game_view_container_spec.js.coffee
@@ -45,20 +45,3 @@ describe 'Shared.BaseGameViewContainer', ->
       Ember.run.end()
 
       (expect @baseGameViewContainer.$()).toContain '#' + @testContentViewId
-
-  describe 'destroying', ->
-
-    beforeEach ->
-      @viewStub =
-        destroy: sinon.spy()
-
-      @baseGameViewContainer = Shared.BaseGameViewContainer.create
-        trackView: @viewStub
-        carView: @viewStub
-        clockView: @viewStub
-        gameView: @viewStub
-
-    it 'should call destroy on all dynamic views', ->
-      @baseGameViewContainer.destroy()
-
-      (expect @viewStub.destroy).toHaveBeenCalledFourTimes()

--- a/spec/javascripts/unit/slotcars/slotcars_application_spec.js.coffee
+++ b/spec/javascripts/unit/slotcars/slotcars_application_spec.js.coffee
@@ -28,18 +28,6 @@ describe 'slotcars application screen management', ->
       (expect @screenFactoryMock.getInstanceOf).toHaveBeenCalledWith 'ExampleScreen', createParameters
       (expect @screenMock.append).toHaveBeenCalled()
 
-    it 'should call the destroy method on the old screen when the screens get switched', ->
-      @firstScreenMock =
-        append: sinon.spy(),
-        destroy: sinon.spy()
-
-      (@screenFactoryMock.getInstanceOf.withArgs 'FirstScreen').returns @firstScreenMock
-
-      @slotcarsApplication.showScreen 'FirstScreen'
-      @slotcarsApplication.showScreen 'SecondScreen'
-
-      (expect @firstScreenMock.destroy).toHaveBeenCalled()
-
 
   describe 'integration with the route manager', ->
 


### PR DESCRIPTION
Introduces a 'Quickplay' button in the PlayScreen, next to the 'Restart' button. This is handled with an touch/click listener instead of a normal link because a link wouldn´t work if you already are in the 'Quickplay' route state. The listener sends 'quickplay' to the route manger which then reacts accordingly.

It was not that easy to get it work because the PlayScreen (which is used by the Play AND the Quickplay state) gets destroyed too late and entering the next state causes the creation of a new PlayScreen. So, I delayed the creation of the PlayScreen when entering Quickplay by 500ms.

Also, there is now a `Shared.RouteState` which tells the application to destroy the current screen when exiting the state.
Finally, I cleaned up the `Game`, `BaseGame`, and `BaseGameViewContainer`.
