### PR TITLE
Bug/tracks are cropped

### DIFF
--- a/app/assets/javascripts/slotcars/build/templates/draw_view_template.js.hjs
+++ b/app/assets/javascripts/slotcars/build/templates/draw_view_template.js.hjs
@@ -2,5 +2,3 @@
   <p>Use your finger to draw a track!</p>
   <img src="assets/views/build/finger.png" alt="Use your finger to draw a track!" />
 </div>
-
-<div id="draw-view-paper"></div>

--- a/app/assets/javascripts/slotcars/build/views/draw_view.js.coffee
+++ b/app/assets/javascripts/slotcars/build/views/draw_view.js.coffee
@@ -1,7 +1,4 @@
-
 #= require slotcars/shared/views/track_view
-
-PAPER_WRAPPER_ID = '#draw-view-paper'
 
 Build.DrawView = Shared.TrackView.extend
 
@@ -11,17 +8,12 @@ Build.DrawView = Shared.TrackView.extend
   elementId: 'build-draw-view'
   drawController: null
 
-  _rasterizedTrackPath: null
-
   didInsertElement: ->
-    @_paper = Raphael @$(PAPER_WRAPPER_ID)[0], 1024, 768
+    @_super()
+    @$().on 'touchMouseDown', (event) => @_onTouchMouseDown(event)
+    @$().on 'touchMouseUp', (event) => @_onTouchMouseUp(event)
 
-    @$(PAPER_WRAPPER_ID).on 'touchMouseDown', (event) => @_onTouchMouseDown(event)
-    @$(PAPER_WRAPPER_ID).on 'touchMouseUp', (event) => @_onTouchMouseUp(event)
-
-    @drawTrack @track.get 'raphaelPath'
-
-  # overrides TrackView.drawTrack for specialized drawing in builder
+  # overrides TrackView.drawTrack for specialized rendering in draw mode
   drawTrack: (path) ->
     return unless @_paper?
     @_paper.clear()
@@ -34,13 +26,13 @@ Build.DrawView = Shared.TrackView.extend
     @_super path
 
   willDestroyElement: ->
-    @$(PAPER_WRAPPER_ID).off 'touchMouseDown'
-    @$(PAPER_WRAPPER_ID).off 'touchMouseUp'
+    @$().off 'touchMouseDown'
+    @$().off 'touchMouseUp'
 
   _onTouchMouseDown: (event) ->
     event.stopPropagation()
     @$('#draw-info').animate opacity: 0
-    @$(PAPER_WRAPPER_ID).on 'touchMouseMove', (event) => @_onTouchMouseMove(event)
+    @$().on 'touchMouseMove', (event) => @_onTouchMouseMove(event)
 
   _onTouchMouseMove: (event) ->
     event.stopPropagation()
@@ -50,5 +42,5 @@ Build.DrawView = Shared.TrackView.extend
 
   _onTouchMouseUp: (event) ->
     event.stopPropagation()
-    @$(PAPER_WRAPPER_ID).off 'touchMouseMove'
+    @$().off 'touchMouseMove'
     @drawController.onTouchMouseUp()

--- a/app/assets/javascripts/slotcars/build/views/edit_view.js.coffee
+++ b/app/assets/javascripts/slotcars/build/views/edit_view.js.coffee
@@ -4,10 +4,12 @@ Build.EditView = Shared.TrackView.extend
 
   circles: null
   excludedPathLayers: outerLine: true, slot: true
+  boundaries:
+    min: x: 0, y: 100
+    max: x: SCREEN_WIDTH, y: SCREEN_HEIGHT
 
   drawTrack: (path) ->
     @_super path
-
     @pathPoints = @track.getPathPoints() unless @pathPoints?
     @_drawEditingHandles()
 
@@ -23,6 +25,7 @@ Build.EditView = Shared.TrackView.extend
 
     @circles.data 'viewContext', this
     @circles.drag @_onEditHandleMove, @_onEditHandleDragStart, @_onEditHandleDragEnd
+    @circles.transform "t#{@scaledOffset},#{@scaledOffset}"
 
   _onEditHandleDragEnd: (x, y, event) ->
     @animate { r: 34, opacity: 1 }, 300, 'bounce'
@@ -34,10 +37,18 @@ Build.EditView = Shared.TrackView.extend
   _onEditHandleMove: (deltaX, deltaY, x, y, event) ->
     X = (@attr 'cx') + (deltaX - @deltaX)
     Y = (@attr 'cy') + (deltaY - @deltaY)
-    @attr cx: X, cy: Y
 
-    @deltaX = deltaX
-    @deltaY = deltaY
+    boundaries = (@data 'viewContext').boundaries
+
+    if      X < boundaries.min.x then X = boundaries.min.x
+    else if X > boundaries.max.x then X = boundaries.max.x
+    else  @deltaX = deltaX
+
+    if      Y < boundaries.min.y then Y = boundaries.min.y
+    else if Y > boundaries.max.y then Y = boundaries.max.y
+    else    @deltaY = deltaY
+
+    @attr cx: X, cy: Y
 
     (@data 'viewContext').updatePathPoint (@data 'index'), { x: X, y: Y }
 

--- a/app/assets/javascripts/slotcars/build/views/edit_view.js.coffee
+++ b/app/assets/javascripts/slotcars/build/views/edit_view.js.coffee
@@ -5,8 +5,8 @@ Build.EditView = Shared.TrackView.extend
   circles: null
   excludedPathLayers: outerLine: true, slot: true
   boundaries:
-    min: x: 0, y: 100
-    max: x: SCREEN_WIDTH, y: SCREEN_HEIGHT
+    minimum: x: 0, y: 100
+    maximum: x: SCREEN_WIDTH, y: SCREEN_HEIGHT
 
   drawTrack: (path) ->
     @_super path
@@ -35,22 +35,22 @@ Build.EditView = Shared.TrackView.extend
     @animate { r: 49, opacity: .7 }, 300, '<'
 
   _onEditHandleMove: (deltaX, deltaY, x, y, event) ->
-    X = (@attr 'cx') + (deltaX - @deltaX)
-    Y = (@attr 'cy') + (deltaY - @deltaY)
+    x = (@attr 'cx') + (deltaX - @deltaX)
+    y = (@attr 'cy') + (deltaY - @deltaY)
 
     boundaries = (@data 'viewContext').boundaries
 
-    if      X < boundaries.min.x then X = boundaries.min.x
-    else if X > boundaries.max.x then X = boundaries.max.x
+    if      x < boundaries.minimum.x then x = boundaries.minimum.x
+    else if x > boundaries.maximum.x then x = boundaries.maximum.x
     else  @deltaX = deltaX
 
-    if      Y < boundaries.min.y then Y = boundaries.min.y
-    else if Y > boundaries.max.y then Y = boundaries.max.y
+    if      y < boundaries.minimum.y then y = boundaries.minimum.y
+    else if y > boundaries.maximum.y then y = boundaries.maximum.y
     else    @deltaY = deltaY
 
-    @attr cx: X, cy: Y
+    @attr cx: x, cy: y
 
-    (@data 'viewContext').updatePathPoint (@data 'index'), { x: X, y: Y }
+    (@data 'viewContext').updatePathPoint (@data 'index'), { x: x, y: y }
 
   updatePathPoint: (index, newPoint) ->
     @pathPoints[index] = newPoint

--- a/app/assets/javascripts/slotcars/build/views/rasterization_view.js.coffee
+++ b/app/assets/javascripts/slotcars/build/views/rasterization_view.js.coffee
@@ -2,7 +2,7 @@
 #= require slotcars/shared/views/track_view
 
 Build.RasterizationView = Shared.TrackView.extend
-  
+
   templateName: 'slotcars_build_templates_rasterization_view_template'
   track: null
 
@@ -11,7 +11,6 @@ Build.RasterizationView = Shared.TrackView.extend
 
   drawTrack: (path) ->
     @_super path
-
     @_drawTrackOverlay (@get 'track').get 'rasterizedPath'
 
   onRasterizedPathChanged: (->

--- a/app/assets/javascripts/slotcars/play/mixins/finishable.js.coffee.erb
+++ b/app/assets/javascripts/slotcars/play/mixins/finishable.js.coffee.erb
@@ -1,8 +1,11 @@
-FINISH_LINE_DATA_URI = '<%= asset_data_uri 'views/play/finish-line.png' %>'
+FINISH_LINE_DATA_URI = "<%= asset_data_uri 'views/play/finish-line.png' %>"
 
 Play.Finishable = Ember.Mixin.create
 
   track: Ember.required()
+  scaleFactor: Ember.required()
+  paperOffset: Ember.required()
+  renderCanvas: Ember.required()
   finishLineImage: null
 
   FINISH_LINE_START_POINT_OFFSET: 20
@@ -10,10 +13,10 @@ Play.Finishable = Ember.Mixin.create
 
   FINISH_LINE_X_OFFSET: -35
   FINISH_LINE_Y_OFFSET: -10
-  
+
   FINISH_LINE_WIDTH: 70
   FINISH_LINE_HEIGHT: 20
-    
+
   didRenderTrack: ->
     @_super()
     @createFinishLineImage()
@@ -39,7 +42,7 @@ Play.Finishable = Ember.Mixin.create
     scaledFinishLineWidth = @FINISH_LINE_WIDTH * @scaleFactor
     scaledFinishLineHeight = @FINISH_LINE_HEIGHT * @scaleFactor
 
-    canvasContext.translate startPoint.x * @scaleFactor, startPoint.y * @scaleFactor
+    canvasContext.translate startPoint.x * @scaleFactor + @paperOffset, startPoint.y * @scaleFactor + @paperOffset
     canvasContext.rotate finishLineVector.clockwiseAngle() * Math.PI / 180
     canvasContext.translate @FINISH_LINE_X_OFFSET * @scaleFactor, @FINISH_LINE_Y_OFFSET * @scaleFactor
     canvasContext.drawImage @finishLineImage, 0, 0, scaledFinishLineWidth, scaledFinishLineHeight

--- a/app/assets/javascripts/slotcars/shared/mixins/canvas_renderable.js.coffee
+++ b/app/assets/javascripts/slotcars/shared/mixins/canvas_renderable.js.coffee
@@ -1,12 +1,13 @@
 Shared.CanvasRenderable = Ember.Mixin.create
 
   renderCanvas: null
+  scaledOffset: Ember.required()
 
   didInsertElement: ->
     @_super()
     @renderAsCanvas()
 
-  renderAsCanvas: () ->
+  renderAsCanvas: ->
     @createRenderCanvas()
     @renderTrack()
 
@@ -27,6 +28,7 @@ Shared.CanvasRenderable = Ember.Mixin.create
 
   # can be used by other mixins to hook in before the canvas is displayed
   didRenderTrack: ->
+    @renderCanvas.css position: 'relative', top: - @scaledOffset, left: - @scaledOffset
 
   replacePaperWithCanvas: ->
     @removePaperAndElements()

--- a/app/assets/javascripts/slotcars/shared/mixins/panable.js.coffee
+++ b/app/assets/javascripts/slotcars/shared/mixins/panable.js.coffee
@@ -2,18 +2,17 @@ Shared.Panable = Ember.Mixin.create
 
   car: Ember.required()
   classNames: ['panable']
-
-  didInsertElement: ->
-    @$().css 'width', SCREEN_WIDTH * @scaleFactor
-    @$().css 'height', SCREEN_HEIGHT * @scaleFactor
-
-    @_super()
+  padding:
+    left: SCREEN_WIDTH
+    top: SCREEN_HEIGHT
 
   onCarPositionChange: ( ->
     position = @car.position
+
+    # calculation steps: 1. scale position, 2. shift to center (subtract half screen size), 3. add padding
     drawPosition =
-      x: position.x * @scaleFactor
-      y: position.y * @scaleFactor
+      x: position.x * @scaleFactor - SCREEN_WIDTH/2  + @padding.left
+      y: position.y * @scaleFactor - SCREEN_HEIGHT/2 + @padding.top
 
     if @$()?
       @$().css '-webkit-backface-visibility', 'hidden'

--- a/app/assets/javascripts/slotcars/shared/mixins/panable.js.coffee
+++ b/app/assets/javascripts/slotcars/shared/mixins/panable.js.coffee
@@ -11,8 +11,8 @@ Shared.Panable = Ember.Mixin.create
 
     # calculation steps: 1. scale position, 2. shift to center (subtract half screen size), 3. add padding
     drawPosition =
-      x: position.x * @scaleFactor - SCREEN_WIDTH/2  + @padding.left
-      y: position.y * @scaleFactor - SCREEN_HEIGHT/2 + @padding.top
+      x: position.x * @scaleFactor - (SCREEN_WIDTH / 2)  + @padding.left
+      y: position.y * @scaleFactor - (SCREEN_HEIGHT / 2) + @padding.top
 
     if @$()?
       @$().css '-webkit-backface-visibility', 'hidden'

--- a/app/assets/javascripts/slotcars/shared/views/track_view.js.coffee
+++ b/app/assets/javascripts/slotcars/shared/views/track_view.js.coffee
@@ -4,6 +4,7 @@
 Shared.TrackView = Ember.View.extend
 
   track: null
+  classNames: [ 'track-view' ]
   _displayedRaphaelElements: []
   _paper: null
 
@@ -12,6 +13,8 @@ Shared.TrackView = Ember.View.extend
   excludedPathLayers: {}
 
   scaleFactor: 1
+  paperOffset: 150 # remember to change 'top' and 'left' of '.track-view svg' in stylesheet
+  scaledOffset: null
 
   SLOT_WIDTH: 3
   SLOT_EDGE_WIDTH: 8
@@ -32,8 +35,17 @@ Shared.TrackView = Ember.View.extend
     @updateTrack @track.get 'raphaelPath'
   ).observes 'track.raphaelPath'
 
+  init: ->
+    @_super()
+    @scaledOffset = @paperOffset * @scaleFactor
+
   didInsertElement: ->
-    @_paper = Raphael @$()[0], SCREEN_WIDTH * @scaleFactor, SCREEN_HEIGHT * @scaleFactor
+    @_super()
+    @_paper = Raphael @$()[0], (SCREEN_WIDTH + 2 * @paperOffset) * @scaleFactor, (SCREEN_HEIGHT + 2 * @paperOffset) * @scaleFactor
+
+    @$().css width: SCREEN_WIDTH * @scaleFactor, height: SCREEN_HEIGHT * @scaleFactor
+    @$('svg').css top: - @scaledOffset, left: - @scaledOffset
+
     @drawTrack @track.get 'raphaelPath'
 
   updateTrack: (path) ->
@@ -62,7 +74,7 @@ Shared.TrackView = Ember.View.extend
     path.attr 'stroke', color
     path.attr 'stroke-width', width
 
-    path.transform "s#{@scaleFactor},#{@scaleFactor},0,0"
+    path.transform "t#{@scaledOffset},#{@scaledOffset}s#{@scaleFactor},#{@scaleFactor},0,0"
 
     @_displayedRaphaelElements.push path
 

--- a/app/assets/stylesheets/global.css.scss
+++ b/app/assets/stylesheets/global.css.scss
@@ -30,8 +30,10 @@ a, button { outline: none; }
 .panable {
   background-image: image-url("global/grass-pattern.jpg");
   background-repeat: repeat;
-  padding: ($screen-height / 2) ($screen-width / 2);
+  padding: $screen-height $screen-width;
 }
+
+.track-view { position: relative; }
 
 .default-button {
   display: inline-block;

--- a/app/assets/stylesheets/views/build_screen_view.css.scss
+++ b/app/assets/stylesheets/views/build_screen_view.css.scss
@@ -76,6 +76,11 @@
     left: 385px;
     color: #111;
   }
+  .track-view svg {
+    position: absolute !important;
+    top: -150px;  /* adjust to 'paperOffset' in TrackView */
+    left: -150px; /* adjust to 'paperOffset' in TrackView */
+  }
 }
 
 #authorization-view-buttons {

--- a/spec/javascripts/unit/slotcars/build/views/draw_view_spec.js.coffee
+++ b/spec/javascripts/unit/slotcars/build/views/draw_view_spec.js.coffee
@@ -1,7 +1,5 @@
 describe 'Build.DrawView', ->
 
-  DRAW_VIEW_PAPER_WRAPPER_ID = '#draw-view-paper'
-
   it 'should extend TrackView', ->
     (expect Build.DrawView).toExtend Shared.TrackView
 
@@ -17,7 +15,6 @@ describe 'Build.DrawView', ->
       clear: sinon.spy()
 
     @raphaelStub = window.Raphael = sinon.stub().returns @paperStub
-
 
   afterEach ->
     window.Raphael = @raphaelBackup
@@ -45,7 +42,7 @@ describe 'Build.DrawView', ->
     afterEach -> @track.restore()
 
     it 'should create raphael paper', ->
-      (expect @raphaelStub).toHaveBeenCalledWith @drawView.$(DRAW_VIEW_PAPER_WRAPPER_ID)[0], SCREEN_WIDTH, SCREEN_HEIGHT
+      (expect @raphaelStub).toHaveBeenCalledWith @drawView.$()[0], (SCREEN_WIDTH + 2 * @drawView.paperOffset), (SCREEN_HEIGHT + 2 * @drawView.paperOffset)
 
     it 'should draw the track', ->
       (expect @paperStub.path).toHaveBeenCalledWith @originalTestPath
@@ -91,25 +88,25 @@ describe 'Build.DrawView', ->
         @drawControllerMock.onTouchMouseMove = sinon.spy()
 
       it 'should not bind mouse move before mouse down happened', ->
-        (jQuery @drawView.$(DRAW_VIEW_PAPER_WRAPPER_ID)).trigger 'touchMouseMove'
+        (jQuery @drawView.$()).trigger 'touchMouseMove'
 
         (expect @drawControllerMock.onTouchMouseMove).not.toHaveBeenCalled()
 
 
       it 'should bind mouse move on mouse down', ->
-        @drawView.$(DRAW_VIEW_PAPER_WRAPPER_ID).trigger 'touchMouseDown'
-        @drawView.$(DRAW_VIEW_PAPER_WRAPPER_ID).trigger 'touchMouseMove'
+        @drawView.$().trigger 'touchMouseDown'
+        @drawView.$().trigger 'touchMouseMove'
 
         (expect @drawControllerMock.onTouchMouseMove).toHaveBeenCalled()
 
       it 'should notifiy draw controller of move events', ->
-        @drawView.$(DRAW_VIEW_PAPER_WRAPPER_ID).trigger 'touchMouseDown'
+        @drawView.$().trigger 'touchMouseDown'
 
         # manually create touch mouse move event
         testPosition = x: 3, y: 4
         touchMouseMoveEvent = jQuery.Event 'touchMouseMove', pageX: testPosition.x, pageY: testPosition.y
 
-        @drawView.$(DRAW_VIEW_PAPER_WRAPPER_ID).trigger touchMouseMoveEvent
+        @drawView.$().trigger touchMouseMoveEvent
 
         (expect @drawControllerMock.onTouchMouseMove).toHaveBeenCalledWithAnObjectLike testPosition
 
@@ -120,22 +117,22 @@ describe 'Build.DrawView', ->
         @drawControllerMock.onTouchMouseUp = sinon.spy()
 
       it 'should setup mouse up listeners and tell controller about events', ->
-        (jQuery @drawView.$(DRAW_VIEW_PAPER_WRAPPER_ID)).trigger 'touchMouseUp'
+        (jQuery @drawView.$()).trigger 'touchMouseUp'
 
         (expect @drawControllerMock.onTouchMouseUp).toHaveBeenCalled()
 
       it 'should unbind the mouse up event when removed', ->
         @drawView.willDestroyElement()
-        (jQuery @drawView.$(DRAW_VIEW_PAPER_WRAPPER_ID)).trigger 'touchMouseUp'
+        (jQuery @drawView.$()).trigger 'touchMouseUp'
 
         (expect @drawControllerMock.onTouchMouseUp).not.toHaveBeenCalled()
 
       it 'should unbind the mouse move event', ->
         @drawControllerMock.onTouchMouseMove = sinon.spy()
 
-        (jQuery @drawView.$(DRAW_VIEW_PAPER_WRAPPER_ID)).trigger 'touchMouseDown'
-        (jQuery @drawView.$(DRAW_VIEW_PAPER_WRAPPER_ID)).trigger 'touchMouseUp'
+        (jQuery @drawView.$()).trigger 'touchMouseDown'
+        (jQuery @drawView.$()).trigger 'touchMouseUp'
 
-        (jQuery @drawView.$(DRAW_VIEW_PAPER_WRAPPER_ID)).trigger 'touchMouseMove'
+        (jQuery @drawView.$()).trigger 'touchMouseMove'
 
         (expect @drawControllerMock.onTouchMouseMove).not.toHaveBeenCalled()

--- a/spec/javascripts/unit/slotcars/play/game_spec.js.coffee
+++ b/spec/javascripts/unit/slotcars/play/game_spec.js.coffee
@@ -14,6 +14,9 @@ describe 'Play.Game', ->
       gameController: {}
       track: @trackMock
       car: @carMock
+      scaledOffset: 0 # required
+      paperOffset: 0  # required
+      scaleFactor: 1  # required
 
     @CarViewMock = mockEmberClass Play.CarView
     @GameViewMock = mockEmberClass Play.GameView

--- a/spec/javascripts/unit/slotcars/play/mixins/finishable_spec.js.coffee
+++ b/spec/javascripts/unit/slotcars/play/mixins/finishable_spec.js.coffee
@@ -1,6 +1,22 @@
 
 describe 'Play.Finishable', ->
 
+  it 'should always require scaleFactor', ->
+    # Ember.required() just works/fires when the mixin is applied after creation
+    (expect => Play.Finishable.apply Ember.Object.create paperOffset: 0, renderCanvas: {}, track: {}).toThrow()
+
+  it 'should always require paperOffset', ->
+    # Ember.required() just works/fires when the mixin is applied after creation
+    (expect => Play.Finishable.apply Ember.Object.create scaleFactor: 0, renderCanvas: {}, track: {}).toThrow()
+
+  it 'should always require a track', ->
+    # Ember.required() just works/fires when the mixin is applied after creation
+    (expect => Play.Finishable.apply Ember.Object.create scaleFactor: 0, paperOffset: 0, renderCanvas: {}).toThrow()
+
+  it 'should always require a canvas object', ->
+    # Ember.required() just works/fires when the mixin is applied after creation
+    (expect => Play.Finishable.apply Ember.Object.create scaleFactor: 0, paperOffset: 0, track: {}).toThrow()
+
   beforeEach ->
     @trackMock = {}
     @finishable = Ember.Object.extend(Play.Finishable).create
@@ -17,10 +33,10 @@ describe 'Play.Finishable', ->
       @finishable.didRenderTrack()
 
       (expect @finishable._super).toHaveBeenCalled()
-      
+
     it 'should create the headline image', ->
       @finishable.didRenderTrack()
-      
+
       (expect @finishable.createFinishLineImage).toHaveBeenCalled()
 
     it 'should start loading the finish line image', ->

--- a/spec/javascripts/unit/slotcars/shared/components/container_spec.js.coffee
+++ b/spec/javascripts/unit/slotcars/shared/components/container_spec.js.coffee
@@ -1,7 +1,6 @@
 describe 'Shared.Container', ->
 
   it 'should always require a view', ->
-    # applies the Appendable mixin on an object - assumes an error when 'view' property is not set
     # Ember.required() just works/fires when the mixin is applied after creation
     (expect => Shared.Container.apply Ember.Object.create()).toThrow()
 
@@ -13,7 +12,6 @@ describe 'Shared.Container', ->
       @viewMock = {}
 
       @container = Ember.Object.extend(Shared.Container).create view: @containerViewMock
-
 
     it 'should tell the container view to set the view as attribute with location name', ->
       location = 'testLocation'

--- a/spec/javascripts/unit/slotcars/shared/lib/base_game_spec.js.coffee
+++ b/spec/javascripts/unit/slotcars/shared/lib/base_game_spec.js.coffee
@@ -9,6 +9,9 @@ describe 'Shared.BaseGame', ->
     @TrackViewMock = mockEmberClass Shared.TrackView,
       gameController: {}
       car: @carMock
+      scaledOffset: 0 # required
+      paperOffset: 0  # required
+      scaleFactor: 1  # required
 
     @CarViewMock = mockEmberClass Play.CarView
     @BaseGameViewContainerMock = mockEmberClass Shared.BaseGameViewContainer, set: sinon.spy()

--- a/spec/javascripts/unit/slotcars/shared/mixins/canvas_renderable_spec.js.coffee
+++ b/spec/javascripts/unit/slotcars/shared/mixins/canvas_renderable_spec.js.coffee
@@ -1,9 +1,11 @@
-
 describe 'Shared.CanvasRenderable', ->
 
-  beforeEach ->
-    @canvasRenderable = (Ember.Object.extend Shared.CanvasRenderable).create()
+  it 'should always require scaledOffset', ->
+    # Ember.required() just works/fires when the mixin is applied after creation
+    (expect => Play.CanvasRenderable.apply Ember.Object.create()).toThrow()
 
+  beforeEach ->
+    @canvasRenderable = Shared.CanvasRenderable.apply Ember.Object.create scaledOffset: 0
 
   describe 'hooking into track view rendering process', ->
 
@@ -21,7 +23,6 @@ describe 'Shared.CanvasRenderable', ->
 
       (expect @canvasRenderable._super).toHaveBeenCalled()
 
-
   describe 'rendering as canvas', ->
 
     beforeEach ->
@@ -37,7 +38,6 @@ describe 'Shared.CanvasRenderable', ->
       @canvasRenderable.renderAsCanvas()
 
       (expect @canvasRenderable.renderTrack).toHaveBeenCalled()
-
 
   describe 'creating render canvas', ->
 

--- a/spec/javascripts/unit/slotcars/shared/views/track_view_spec.js.coffee
+++ b/spec/javascripts/unit/slotcars/shared/views/track_view_spec.js.coffee
@@ -1,8 +1,7 @@
-describe 'track view', ->
+describe 'TrackView', ->
 
   beforeEach ->
     @raphaelBackup = window.Raphael
-
     @paperElementAttrSpy = sinon.spy()
 
     @raphaelElementStub = sinon.stub().returns
@@ -15,7 +14,6 @@ describe 'track view', ->
       remove: sinon.spy()
 
     @raphaelStub = window.Raphael = sinon.stub().returns @paperStub
-
     @trackMock = mockEmberClass Shared.Track
 
     @trackView = Shared.TrackView.create
@@ -28,14 +26,22 @@ describe 'track view', ->
   it 'should be a subclass of ember view', ->
     (expect Shared.TrackView).toExtend Ember.View
 
-  describe 'appendeding view to DOM', ->
+  it 'should calculate the scaled offset on creation', ->
+    trackView = Shared.TrackView.create
+      paperOffset: 20
+      scaleFactor: 1.5
+      scaledOffset: 0
+
+    (expect trackView.scaledOffset).toEqual 30
+
+  describe 'appendding view to DOM', ->
 
     beforeEach ->
       @trackView.appendTo '<div>'
       Ember.run.end()
 
     it 'should create raphael paper', ->
-      (expect @raphaelStub).toHaveBeenCalledWith @trackView.$()[0], SCREEN_WIDTH * @trackView.scaleFactor, SCREEN_HEIGHT * @trackView.scaleFactor
+      (expect @raphaelStub).toHaveBeenCalledWith @trackView.$()[0], (SCREEN_WIDTH + 2 * @trackView.paperOffset) * @trackView.scaleFactor, (SCREEN_HEIGHT + 2 * @trackView.paperOffset) * @trackView.scaleFactor
 
     it 'should draw the track', ->
       raphaelPath = "M0,0R1,0z"
@@ -45,13 +51,6 @@ describe 'track view', ->
       @trackView.didInsertElement()
 
       (expect @trackView.drawTrack).toHaveBeenCalledWith raphaelPath
-
-  describe 'drawing the track', ->
-
-    it 'should not ignore drawing if not inserted in DOM', ->
-      trackView = Shared.TrackView.create()
-
-      (expect trackView.drawTrack).not.toThrow()
 
   describe 'updating the track', ->
 
@@ -85,7 +84,7 @@ describe 'track view', ->
       @trackView.appendTo '<div>'
       Ember.run.end()
 
-    it 'should clear the paper', ->
+    it 'should remove the paper', ->
       @trackView.destroy()
 
       (expect @paperStub.remove).toHaveBeenCalled()


### PR DESCRIPTION
Introduces `paperOffset` (and `scaledOffset`) on `TrackView`. The paperOffset is considered when drawing the track. The old tracks are still correct as the builder saves path points the same way as it did before. This way the paperOffset can be changed if necessary without making all old tracks useless.

The EditView now considers `boundaries` when the edit points are moved, so that the points can´t be dragged outside the window any longer.

The DrawView was simplified by removing the container in which the SVG Element was inserted before. This way, it is now quite close to the TrackView which it extends. Binding event listeners is now the only difference in the setup.

The Panable mixin got a `padding` property to easier and faster change the padding.
