### PR TITLE
Feature/add notice for unsupported browsers

### DIFF
--- a/app/assets/javascripts/slotcars/errors/templates/error_screen_view_template.js.hjs
+++ b/app/assets/javascripts/slotcars/errors/templates/error_screen_view_template.js.hjs
@@ -1,8 +1,14 @@
+<h1>slotcars</h1>
+
 <div id="error-overlay">
-  <p>Oooops &hellip; Looks like something went wrong here. To continue take one of the opportunities given below.</p>
+  <p><strong>Oooops &hellip;</strong></p>
+  <p>Looks like something went wrong here. To continue, choose one of the options below.</p>
   <div class="buttons">
-    <a class="default-button" href="/">go home!</a>
-    <a class="default-button" href="tracks">choose a track</a>  
-    <a class="default-button" href="quickplay">do a quickplay</a>  
+    <a class="default-button js-route" href="">Home</a>
+    <a class="default-button js-route" href="tracks">Choose a track</a>
+    <a class="default-button js-route" href="quickplay">Quickplay</a>
   </div>
 </div>
+
+<img id="top-curve" src="assets/views/home/top-curve.png">
+<img id="bottom-curve" src="assets/views/home/bottom-curve.png">

--- a/app/assets/javascripts/slotcars/errors/templates/unsupported_screen_view_template.js.hjs
+++ b/app/assets/javascripts/slotcars/errors/templates/unsupported_screen_view_template.js.hjs
@@ -2,7 +2,7 @@
 
 <div id="error-overlay">
   <p><strong>Hi racer &hellip;</strong></p>
-  <p>We are pleased that you want to play our game <strong>'slotcars'</strong>. Sadly, it currently just works in Google Chrome and Safari. Please switch to one of those to get involved and increase your racing experience to compete with your friends!</p>
+  <p>We are pleased that you want to play our game <strong>'slotcars'</strong>. Sadly, it currently just works in Google Chrome and Safari. Please switch to one of those to get involved and compete with your friends!</p>
 </div>
 
 <img id="top-curve" src="assets/views/home/top-curve.png">

--- a/app/assets/javascripts/slotcars/errors/templates/unsupported_screen_view_template.js.hjs
+++ b/app/assets/javascripts/slotcars/errors/templates/unsupported_screen_view_template.js.hjs
@@ -1,0 +1,9 @@
+<h1>slotcars</h1>
+
+<div id="error-overlay">
+  <p><strong>Hi racer &hellip;</strong></p>
+  <p>We are pleased that you want to play our game <strong>'slotcars'</strong>. Sadly, it currently just works in Google Chrome and Safari. Please switch to one of those to get involved and increase your racing experience to compete with your friends!</p>
+</div>
+
+<img id="top-curve" src="assets/views/home/top-curve.png">
+<img id="bottom-curve" src="assets/views/home/bottom-curve.png">

--- a/app/assets/javascripts/slotcars/errors/unsupported_screen.js.coffee
+++ b/app/assets/javascripts/slotcars/errors/unsupported_screen.js.coffee
@@ -1,0 +1,7 @@
+#= require slotcars/factories/screen_factory
+
+Errors.UnsupportedScreen = Ember.Object.extend
+
+  init: -> @view = Errors.UnsupportedScreenView.create()
+
+Shared.ScreenFactory.getInstance().registerScreen 'UnsupportedScreen', Errors.UnsupportedScreen

--- a/app/assets/javascripts/slotcars/errors/views/unsupported_screen_view.js.coffee
+++ b/app/assets/javascripts/slotcars/errors/views/unsupported_screen_view.js.coffee
@@ -1,0 +1,4 @@
+Errors.UnsupportedScreenView = Ember.View.extend
+
+  elementId: 'unsupported-screen-view'
+  templateName: 'slotcars_errors_templates_unsupported_screen_view_template'

--- a/app/assets/javascripts/slotcars/play/controllers/game_controller.js.coffee
+++ b/app/assets/javascripts/slotcars/play/controllers/game_controller.js.coffee
@@ -157,11 +157,11 @@ Play.GameController = Shared.BaseGameController.extend Play.Countdownable,
     @ghost.drive @raceTime if @ghost?
 
   restartGame: ->
+    @set 'highscores', null
     @set 'isRaceRunning', false
     @set 'isRaceFinished', false
     @set 'raceTime', 0
     @set 'lapTimes', []
-    @set 'highscores', null
 
     @car.reset()
     @ghost.reset() if @ghost?

--- a/app/assets/javascripts/slotcars/play/views/ghost_view.js.coffee
+++ b/app/assets/javascripts/slotcars/play/views/ghost_view.js.coffee
@@ -6,13 +6,16 @@ Play.GhostView = Ember.View.extend
   templateName: 'slotcars_play_templates_ghost_view_template'
   tagName: ''
 
-  didInsertElement: -> @hide()
+  didInsertElement: ->
+    @_super()
+    @hide()
 
-  hide: -> (jQuery '#ghost').hide()
+  hide: -> @$('#ghost').hide()
 
   show: ->
-    (jQuery '#ghost').show()
-    (jQuery '#ghost').css '-webkit-transform', "rotateZ(#{@car.rotation}deg)"
+    @$('#ghost').show()
+    @$('#ghost').css '-webkit-backface-visibility', 'hidden'
+    @$('#ghost').css '-webkit-transform', "rotateZ(#{@car.rotation}deg)"
 
   update: (->
     rotation = @ghost.rotation

--- a/app/assets/javascripts/slotcars/shared/lib/route_manager.js.coffee
+++ b/app/assets/javascripts/slotcars/shared/lib/route_manager.js.coffee
@@ -1,11 +1,21 @@
 Shared.RouteState = Ember.State.extend
   exit: (manager) -> manager.delegate.destroyCurrentScreen()
 
+Shared.BrowserSupportable = Ember.Mixin.create
+  enter: (manager) ->
+    if manager.delegate.isBrowserSupported() then @_super manager
+    else manager.transitionTo 'Unsupported'
+
 Shared.RouteManager = Ember.RouteManager.extend
 
   wantsHistory: true # use html5 push state
   baseURI: window.location.origin || ( window.location.protocol + "//" + window.location.host )
   delegate: null
+
+  init: ->
+    @_super()
+    validStates = ['Home', 'Build', 'Play', 'Quickplay', 'Tracks', 'Error']
+    Shared.BrowserSupportable.apply @states[state] for state in validStates
 
   Build: Shared.RouteState.create
     route: 'build'
@@ -35,6 +45,10 @@ Shared.RouteManager = Ember.RouteManager.extend
   Home: Shared.RouteState.create
     route: ''
     enter: (manager) -> manager.delegate.showScreen 'HomeScreen'
+
+  Unsupported: Shared.RouteState.create
+    route: 'unsupported'
+    enter: (manager) -> manager.delegate.showScreen 'UnsupportedScreen'
 
   404: Ember.State.create
     enter: (manager) -> manager.transitionTo 'Error'

--- a/app/assets/javascripts/slotcars/slotcars_application.js.coffee
+++ b/app/assets/javascripts/slotcars/slotcars_application.js.coffee
@@ -33,3 +33,5 @@ window.SlotcarsApplication = Ember.Application.extend
     @_currentScreen.append()
 
   destroyCurrentScreen: -> @_currentScreen.destroy() if @_currentScreen?
+
+  isBrowserSupported: -> (jQuery.browser.chrome or jQuery.browser.safari) and jQuery.browser.webkit

--- a/app/assets/stylesheets/global.css.scss
+++ b/app/assets/stylesheets/global.css.scss
@@ -1,12 +1,10 @@
 @import "config";
 @import "helpers/mixins";
 
-body {
-  background: url("global/background-noise.jpg") repeat;
-/*  overflow: hidden; */
-}
+body { background: url("global/background-noise.jpg") repeat; }
 
 a, button { outline: none; }
+strong { font-weight: bold; }
 
 #screen-container {
   position: relative;
@@ -15,6 +13,7 @@ a, button { outline: none; }
   margin: 0 auto;
   overflow: hidden;
   background-image: image-url("global/grass-pattern.jpg");
+  background-position: center top;
   background-repeat: repeat;
   font-family: sans-serif;
   @include shadow(0, 0, 50px, 0px, #030303);
@@ -37,18 +36,27 @@ a, button { outline: none; }
 
 .default-button {
   display: inline-block;
+  font-family: "SansitaOneRegular";
+  font-size: 24px;
   text-align: center;
-  font-weight: bold;
-  font-size: 13px;
-  border: 1px solid #666;
-  border-radius: 18px;
+  text-shadow: 0 0 1px rgba(0, 0, 0, 0.7);
+
+  border: 6px solid #861111;
+  @include border-radius(15px);
+  @include shadow(0, 0, 5px, 0, rgba(0, 0, 0, 0.7));
+
   padding: 8px 18px;
   margin: 5px 7px;
-  background-color: white;
-  color: #333;
   text-decoration: none;
+  color: #111;
 
-  &:hover { text-decoration: none; }
+  background-color: white;
+  @include linear-gradient("top, #ffffff 0%, #ffffff 50%, #ebebeb 51%, #fafafa 100%");
+
+  &:hover {
+    text-decoration: none;
+    color: #aa1313;
+  }
   &:active, &:focus { background-color: #cacaca; }
 }
 

--- a/app/assets/stylesheets/global.css.scss
+++ b/app/assets/stylesheets/global.css.scss
@@ -51,7 +51,7 @@ strong { font-weight: bold; }
   color: #111;
 
   background-color: white;
-  @include linear-gradient("top, #ffffff 0%, #ffffff 50%, #ebebeb 51%, #fafafa 100%");
+  @include linear-gradient(top, #ffffff 0%, #ffffff 50%, #ebebeb 51%, #fafafa 100%);
 
   &:hover {
     text-decoration: none;

--- a/app/assets/stylesheets/helpers/mixins.css.scss
+++ b/app/assets/stylesheets/helpers/mixins.css.scss
@@ -23,6 +23,13 @@
           border-radius: $radius;
 }
 
+@mixin linear-gradient($all) {
+  background:    -moz-linear-gradient($all);
+  background: -webkit-linear-gradient($all);
+  background:      -o-linear-gradient($all);
+  background:     -ms-linear-gradient($all);
+}
+
 @mixin widget-base {
   @include rotate(-11deg);
   @include transform-origin(210px, 244px);

--- a/app/assets/stylesheets/helpers/mixins.css.scss
+++ b/app/assets/stylesheets/helpers/mixins.css.scss
@@ -23,11 +23,11 @@
           border-radius: $radius;
 }
 
-@mixin linear-gradient($all) {
-  background:    -moz-linear-gradient($all);
-  background: -webkit-linear-gradient($all);
-  background:      -o-linear-gradient($all);
-  background:     -ms-linear-gradient($all);
+@mixin linear-gradient($one, $two, $three, $four, $five) {
+  background:    -moz-linear-gradient($one, $two, $three, $four, $five);
+  background: -webkit-linear-gradient($one, $two, $three, $four, $five);
+  background:      -o-linear-gradient($one, $two, $three, $four, $five);
+  background:     -ms-linear-gradient($one, $two, $three, $four, $five);
 }
 
 @mixin widget-base {

--- a/app/assets/stylesheets/views/error_screen_view.css.scss
+++ b/app/assets/stylesheets/views/error_screen_view.css.scss
@@ -1,14 +1,40 @@
-#error-overlay {
-  position: absolute; 
-  top: 180px; 
-  left: 150px; 
-  color: white; 
-  font-size: 32px; 
-  font-family: sans-serif; 
-  background-color: rgba(0, 0, 0, 0.7); 
-  -webkit-box-shadow: 0 0 40px rgba(0, 0, 0, 0.7); 
-  width: 700px;
-  padding: 30px;
+@import "config";
+@import "helpers/mixins";
 
-  .buttons { text-align: center; }
+#error-screen-view, #unsupported-screen-view {
+  h1 {
+    position: absolute;
+    bottom: 10px;
+    right: 20px;
+    padding: 0 15px;
+
+    font-family: "SansitaOneRegular";
+    font-size: 110px;
+    text-shadow: 0 2px 2px #666, 0 -2px 2px #000;
+    color: #181818;
+
+    opacity: 0.3;
+  }
+
+  #error-overlay {
+    position: absolute;
+    top: 200px;
+    left: ($screen-width - 760) / 2;
+    width: 700px;
+    padding: 30px;
+    background-color: rgba(0, 0, 0, 0.7);
+
+    @include shadow(0, 0, 40px, 0, rgba(0, 0, 0, 0.7));
+    @include border-radius(18px);
+
+    p {
+      color: white;
+      font-size: 25px;
+      font-family: "JustTheWayYouAre", sans-serif;
+      text-align: center;
+      line-height: 1.4em;
+    }
+
+    .buttons { text-align: center; }
+  }
 }

--- a/app/assets/stylesheets/views/home_screen_view.css.scss
+++ b/app/assets/stylesheets/views/home_screen_view.css.scss
@@ -6,64 +6,66 @@
 @import "helpers/mixins";
 @import "shared/clipboard_button";
 
-h1 {
-  overflow: hidden;
-  text-indent: -10000px;
-  display: block;
-  width: 326px;
-  height: 415px;
-  background-image: image-url("views/home/logo-chain.png");
-  background-repeat: no-repeat;
-  margin-left: 42px;
-}
+#home-screen-view {
+  h1 {
+    overflow: hidden;
+    text-indent: -10000px;
+    display: block;
+    width: 326px;
+    height: 415px;
+    background-image: image-url("views/home/logo-chain.png");
+    background-repeat: no-repeat;
+    margin-left: 42px;
+  }
 
-#home-navigation {
-  position: absolute;
-  top: 225px;
-  left: 48px;
-  list-style: none;
-  z-index: 100;
-}
+  #home-navigation {
+    position: absolute;
+    top: 225px;
+    left: 48px;
+    list-style: none;
+    z-index: 100;
+  }
 
-#quickplay-button {
-  width: 264px;
-  height: 66px;
-  background-image: image-url("views/home/quick-play.png");
-  background-repeat: no-repeat;
+  #quickplay-button {
+    width: 264px;
+    height: 66px;
+    background-image: image-url("views/home/quick-play.png");
+    background-repeat: no-repeat;
 
-  &:hover, &:focus { background-position: 0 -67px; }
-}
+    &:hover, &:focus { background-position: 0 -67px; }
+  }
 
-#tracks-button {
-  width: 264px;
-  height: 76px;
-  margin-top: 10px;
-  background-image: image-url("views/home/choose-track.png");
-  background-repeat: no-repeat;
+  #tracks-button {
+    width: 264px;
+    height: 76px;
+    margin-top: 10px;
+    background-image: image-url("views/home/choose-track.png");
+    background-repeat: no-repeat;
 
-  &:hover, &:focus { background-position: 0 -74px; }
-}
+    &:hover, &:focus { background-position: 0 -74px; }
+  }
 
-#build-button {
-  width: 264px;
-  height: 68px;
-  margin-top: 5px;
-  background-image: image-url("views/home/create-track.png");
-  background-repeat: no-repeat;
+  #build-button {
+    width: 264px;
+    height: 68px;
+    margin-top: 5px;
+    background-image: image-url("views/home/create-track.png");
+    background-repeat: no-repeat;
 
-  &:hover, &:focus { background-position: 0 -67px; }
-}
+    &:hover, &:focus { background-position: 0 -67px; }
+  }
 
-#clipboard {
-  position: absolute;
-  top: 132px;
-  left: 360px;
-  width: 711px;
-  height: 858px;
-  background-image: image-url("shared/clipboard.png");
-  background-repeat: no-repeat;
-  font-family: "JustTheWayYouAre", sans-serif;
-  z-index: 99;
+  #clipboard {
+    position: absolute;
+    top: 132px;
+    left: 360px;
+    width: 711px;
+    height: 858px;
+    background-image: image-url("shared/clipboard.png");
+    background-repeat: no-repeat;
+    font-family: "JustTheWayYouAre", sans-serif;
+    z-index: 99;
+  }
 }
 
 #top-curve {

--- a/spec/javascripts/unit/slotcars/shared/mixins/panable_spec.js.coffee
+++ b/spec/javascripts/unit/slotcars/shared/mixins/panable_spec.js.coffee
@@ -1,4 +1,4 @@
-describe 'Shared.Panalbe', ->
+describe 'Shared.Panable', ->
 
   beforeEach ->
     @car = Shared.Car.create

--- a/spec/javascripts/unit/slotcars/slotcars_application_spec.js.coffee
+++ b/spec/javascripts/unit/slotcars/slotcars_application_spec.js.coffee
@@ -1,12 +1,28 @@
 describe 'slotcars application screen management', ->
 
-  beforeEach ->
-    @RouteManagerMock = mockEmberClass Shared.RouteManager, start: sinon.stub()
+  beforeEach -> @RouteManagerMock = mockEmberClass Shared.RouteManager, start: sinon.stub()
 
-  afterEach ->
-    @RouteManagerMock.restore()
+  afterEach -> @RouteManagerMock.restore()
 
-  describe 'interaction with screens', ->
+  describe '#ready', ->
+
+    beforeEach ->
+      Ember.run => @slotcarsApplication = SlotcarsApplication.create()
+
+    afterEach -> @slotcarsApplication.destroy()
+
+    it 'should create route manager and register itself as delegate', ->
+      (expect @RouteManagerMock.create).toHaveBeenCalledWithAnObjectLike
+        delegate: @slotcarsApplication
+
+    it 'should make the route manager a singleton that can be directly accessed', ->
+      (expect Shared.routeManager).toBe @RouteManagerMock
+
+    it 'should start the route manager', ->
+      (expect Shared.routeManager.start).toHaveBeenCalled()
+
+
+  describe '#showScreen', ->
 
     beforeEach ->
       @screenMock = append: sinon.spy()
@@ -20,7 +36,6 @@ describe 'slotcars application screen management', ->
       @slotcarsApplication.destroy()
       Shared.ScreenFactory.getInstance.restore()
 
-
     it 'should get the correct screen from factory and tell it to append', ->
       createParameters = {}
       @slotcarsApplication.showScreen 'ExampleScreen', createParameters
@@ -29,20 +44,26 @@ describe 'slotcars application screen management', ->
       (expect @screenMock.append).toHaveBeenCalled()
 
 
-  describe 'integration with the route manager', ->
+  describe '#isBrowserSupported', ->
 
     beforeEach ->
+      @browserBackup = jQuery.browser
       Ember.run => @slotcarsApplication = SlotcarsApplication.create()
 
+      sinon.spy @slotcarsApplication, 'isBrowserSupported'
+
     afterEach ->
+      jQuery.browser = @browserBackup
       @slotcarsApplication.destroy()
 
-    it 'should create route manager and register itself as delegate', ->
-      (expect @RouteManagerMock.create).toHaveBeenCalledWithAnObjectLike
-        delegate: @slotcarsApplication
+    it 'should return true if browser is chrome or safari and engine is webkit', ->
+      @slotcarsApplication.isBrowserSupported()
 
-    it 'should make the route manager a singleton that can be directly accessed', ->
-      (expect Shared.routeManager).toBe @RouteManagerMock
+      (expect @slotcarsApplication.isBrowserSupported).toHaveReturned true
 
-    it 'should start the route manager', ->
-      (expect Shared.routeManager.start).toHaveBeenCalled()
+    it 'should return false if browser engine is not webkit', ->
+      jQuery.browser.webkit = false
+
+      @slotcarsApplication.isBrowserSupported()
+
+      (expect @slotcarsApplication.isBrowserSupported).toHaveReturned false


### PR DESCRIPTION
Adds the `UnsupportedScreen`. The `BrowserSupportable` mixin checks whether the current browser is supported (when entering a `RouteState`) and redirects to the `Unsupported` state if not.

This PR contains a pimped design for the `ErrorScreen`.
Also, it finally fixes the bug in the `GameController` which broke the app when trying to restart a race after it already finished (https://www.pivotaltracker.com/story/show/37679203).

**Please checkout this branch an take a look at ErrorScreen and UnsupportedScreen, so we can talk about the 'design'!**
